### PR TITLE
specify the 1sigma ranges for Emiss knobs

### DIFF
--- a/fcl/DIRT2.EmissEngine.Config.fcl
+++ b/fcl/DIRT2.EmissEngine.Config.fcl
@@ -9,6 +9,7 @@ generated_systematic_provider_configuration: {
 				2,
 				4
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_CorrTail_Ar_p"
 			systParamId: 0
@@ -22,6 +23,7 @@ generated_systematic_provider_configuration: {
 				2,
 				4
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_CorrTail_Ar_n"
 			systParamId: 1
@@ -35,6 +37,7 @@ generated_systematic_provider_configuration: {
 				10,
 				30
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ -10, 10 ]
 			prettyName: "Emiss_Linear_Ar_p"
 			systParamId: 2
@@ -48,6 +51,7 @@ generated_systematic_provider_configuration: {
 				10,
 				30
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ -10, 10 ]
 			prettyName: "Emiss_Linear_Ar_n"
 			systParamId: 3
@@ -61,6 +65,7 @@ generated_systematic_provider_configuration: {
 				1.5,
 				2
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_ShiftPeak_Ar_p"
 			systParamId: 4
@@ -74,6 +79,7 @@ generated_systematic_provider_configuration: {
 				1.5,
 				2
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_ShiftPeak_Ar_n"
 			systParamId: 5
@@ -87,6 +93,7 @@ generated_systematic_provider_configuration: {
 				2,
 				4
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_CorrTail_C_p"
 			systParamId: 6
@@ -100,6 +107,7 @@ generated_systematic_provider_configuration: {
 				2,
 				4
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_CorrTail_C_n"
 			systParamId: 7
@@ -113,6 +121,7 @@ generated_systematic_provider_configuration: {
 				10,
 				30
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ -10, 10 ]
 			prettyName: "Emiss_Linear_C_p"
 			systParamId: 8
@@ -126,6 +135,7 @@ generated_systematic_provider_configuration: {
 				10,
 				30
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ -10, 10 ]
 			prettyName: "Emiss_Linear_C_n"
 			systParamId: 9
@@ -139,6 +149,7 @@ generated_systematic_provider_configuration: {
 				1.5,
 				2
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ 0, 0.5 ]
 			prettyName: "Emiss_ShiftPeak_C_p"
 			systParamId: 10
@@ -152,6 +163,7 @@ generated_systematic_provider_configuration: {
 				1.5,
 				2
 			]
+			# fixme: placeholder 1sigma ranges, revisit!
 			oneSigmaShifts: [ 0, 0.5 ]
 			prettyName: "Emiss_ShiftPeak_C_n"
 			systParamId: 11

--- a/fcl/DIRT2.EmissEngine.Config.fcl
+++ b/fcl/DIRT2.EmissEngine.Config.fcl
@@ -9,6 +9,7 @@ generated_systematic_provider_configuration: {
 				2,
 				4
 			]
+			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_CorrTail_Ar_p"
 			systParamId: 0
 		}
@@ -21,6 +22,7 @@ generated_systematic_provider_configuration: {
 				2,
 				4
 			]
+			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_CorrTail_Ar_n"
 			systParamId: 1
 		}
@@ -33,6 +35,7 @@ generated_systematic_provider_configuration: {
 				10,
 				30
 			]
+			oneSigmaShifts: [ -10, 10 ]
 			prettyName: "Emiss_Linear_Ar_p"
 			systParamId: 2
 		}
@@ -45,6 +48,7 @@ generated_systematic_provider_configuration: {
 				10,
 				30
 			]
+			oneSigmaShifts: [ -10, 10 ]
 			prettyName: "Emiss_Linear_Ar_n"
 			systParamId: 3
 		}
@@ -57,6 +61,7 @@ generated_systematic_provider_configuration: {
 				1.5,
 				2
 			]
+			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_ShiftPeak_Ar_p"
 			systParamId: 4
 		}
@@ -69,6 +74,7 @@ generated_systematic_provider_configuration: {
 				1.5,
 				2
 			]
+			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_ShiftPeak_Ar_n"
 			systParamId: 5
 		}
@@ -81,6 +87,7 @@ generated_systematic_provider_configuration: {
 				2,
 				4
 			]
+			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_CorrTail_C_p"
 			systParamId: 6
 		}
@@ -93,6 +100,7 @@ generated_systematic_provider_configuration: {
 				2,
 				4
 			]
+			oneSigmaShifts: [ 0.5, 1.5 ]
 			prettyName: "Emiss_CorrTail_C_n"
 			systParamId: 7
 		}
@@ -105,6 +113,7 @@ generated_systematic_provider_configuration: {
 				10,
 				30
 			]
+			oneSigmaShifts: [ -10, 10 ]
 			prettyName: "Emiss_Linear_C_p"
 			systParamId: 8
 		}
@@ -117,6 +126,7 @@ generated_systematic_provider_configuration: {
 				10,
 				30
 			]
+			oneSigmaShifts: [ -10, 10 ]
 			prettyName: "Emiss_Linear_C_n"
 			systParamId: 9
 		}
@@ -129,6 +139,7 @@ generated_systematic_provider_configuration: {
 				1.5,
 				2
 			]
+			oneSigmaShifts: [ 0, 0.5 ]
 			prettyName: "Emiss_ShiftPeak_C_p"
 			systParamId: 10
 		}
@@ -141,6 +152,7 @@ generated_systematic_provider_configuration: {
 				1.5,
 				2
 			]
+			oneSigmaShifts: [ 0, 0.5 ]
 			prettyName: "Emiss_ShiftPeak_C_n"
 			systParamId: 11
 		}


### PR DESCRIPTION
In the process of developing an interface to the `NOvARwgt` reweighting toolkit I discovered that the Emiss dials do not have 1sigma ranges set in their configuration. The NOvA bridge needs them to exist there (NOvA's systematics interface works in units of sigma) and it's not possible to guess them correctly 100% of the time.

I'm not sure that these are the _correct_ values, however, so let's discuss and I'm happy to adjust them as needed.
