### PR TITLE
Add MINERvA Axial FF for PCA

### DIFF
--- a/fcl/zexpansion_weighter.ToolConfig.fcl
+++ b/fcl/zexpansion_weighter.ToolConfig.fcl
@@ -8,6 +8,7 @@ zexpansion_weighter_toolconfig: {
     b4_variation_descriptor: "(-3,3,1)"
 
     verbosity_level: 5
+    RWtoPub: "PRD_93_113015"
   }
 
 syst_providers: [zexpansion_weighter_toolconfig]

--- a/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
+++ b/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
@@ -156,7 +156,8 @@ bool ZExpPCAWeighter::SetupResponseCalculator(
     Covariance_Matrix = PRD_93_113015::Covariance_Matrix;
   }
   else{
-    std::cout << RWtoPub << " Not available for RWtoPub" << std::endl; 
+    //std::cout << RWtoPub << " Not available for RWtoPub" << std::endl; 
+    throw std::invalid_argument( "Invalid option for RWtoPub, please select Nature_614_102522 or PRD_93_113015" );
   }
 
   // grab the pre-parsed param headers object

--- a/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
+++ b/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
@@ -131,6 +131,9 @@ SystMetaData ZExpPCAWeighter::BuildSystMetaData(fhicl::ParameterSet const &ps,
   tool_options.put("verbosity_level",
                    ps.get<int>("verbosity_level",
                                0)); // put tool config options in papam geaders
+  tool_options.put("RWtoPub",
+                   ps.get<std::string>("RWtoPub",
+                               "PRD_93_113015")); // put tool config options in papam geaders
 
   return smd;
 }

--- a/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
+++ b/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
@@ -30,6 +30,12 @@ using namespace systtools;
 using namespace std;
 
 // global variables
+//
+Eigen::Array4d central_values_a_from_genie = {2.30, -0.60, -3.80, 2.30};
+Eigen::Array4d central_values_afrom_errors_genie_code = {0.14, 0.67, 1,
+                                                         0.75}; //-----in genie
+Eigen::Array4d central_values_afrom_errors_genie = {0.13, 1, 2.5, 2.7};
+
 namespace PRD_93_113015 {
 Eigen::Vector4d a_14_cv{2.3, -0.6, -3.8, 2.3};
 Eigen::Vector4d a_14_errors{0.13, 1, 2.5, 2.7};
@@ -37,10 +43,6 @@ Eigen::MatrixXd Covariance_Matrix{{0.0169, 0.0455, -0.22035, 0.214461},
                                   {0.0455, 1., -2.245, 0.9909},
                                   {-0.22035, -2.245, 6.25, -4.62375},
                                   {0.214461, 0.9909, -4.62375, 7.29}};
-Eigen::Array4d central_values_a_from_genie = {2.30, -0.60, -3.80, 2.30};
-Eigen::Array4d central_values_afrom_errors_genie_code = {0.14, 0.67, 1,
-                                                         0.75}; //-----in genie
-Eigen::Array4d central_values_afrom_errors_genie = {0.13, 1, 2.5, 2.7};
 } // namespace PRD_93_113015
 
 namespace Nature_614_102522 {
@@ -50,10 +52,6 @@ Eigen::MatrixXd Covariance_Matrix{{0.0961, 0.002604, -0.54777, 0.403},
                                   {0.002604, 0.49, -0.4256, -1.365},
                                   {-0.54777, -0.4256, 3.61, -1.2825},
                                   {0.403, -1.365, -1.2825, 6.25}};
-Eigen::Array4d central_values_a_from_genie = {2.30, -0.60, -3.80, 2.30};
-Eigen::Array4d central_values_afrom_errors_genie_code = {0.14, 0.67, 1,
-                                                         0.75}; //-----in genie
-Eigen::Array4d central_values_afrom_errors_genie = {0.13, 1, 2.5, 2.7};
 } // namespace Nature_614_102522
 
 Eigen::MatrixXd
@@ -81,12 +79,12 @@ Eigen::VectorXd ChangeBasisBParams(std::vector<double> const &BVals,
 }
 
 // Function to rescale the a parameters for GENIE ReWeight
-Eigen::Array4d ScaleAparamsforGenie(Eigen::VectorXd &avals) {
+Eigen::Array4d ScaleAparamsforGenie(Eigen::Vector4d a_14_cv, Eigen::VectorXd &avals) {
   Eigen::VectorXd avalues_for_genie =
-      (((Nature_614_102522::a_14_cv + avals).array() /
-        Nature_614_102522::central_values_a_from_genie.array()) -
+      (((a_14_cv + avals).array() /
+        central_values_a_from_genie.array()) -
        1.0) /
-      Nature_614_102522::central_values_afrom_errors_genie_code.array();
+      central_values_afrom_errors_genie_code.array();
   return avalues_for_genie;
 }
 
@@ -140,8 +138,26 @@ SystMetaData ZExpPCAWeighter::BuildSystMetaData(fhicl::ParameterSet const &ps,
 bool ZExpPCAWeighter::SetupResponseCalculator(
     fhicl::ParameterSet const &tool_options) {
   verbosity_level = tool_options.get<int>("verbosity_level", 0);
-  std::string RwtoPub = tool_options.get<std::string>("RWtoPub", "PRD_93_113015");
-  std::cout << "Found RwtoPub: " << RwtoPub << std::endl;
+  std::string RWtoPub = tool_options.get<std::string>("RWtoPub", "PRD_93_113015");
+  std::cout << "Found RwtoPub: " << RWtoPub << std::endl;
+
+  Eigen::Vector4d a_14_cv; 
+  Eigen::Vector4d a_14_errors;
+  Eigen::MatrixXd Covariance_Matrix;
+
+  if(RWtoPub == "Nature_614_102522"){
+    a_14_cv = Nature_614_102522::a_14_cv;
+    a_14_errors = Nature_614_102522::a_14_errors;
+    Covariance_Matrix = Nature_614_102522::Covariance_Matrix;
+  }
+  else if(RWtoPub == "PRD_93_113015"){
+    a_14_cv = PRD_93_113015::a_14_cv;
+    a_14_errors = PRD_93_113015::a_14_errors;
+    Covariance_Matrix = PRD_93_113015::Covariance_Matrix;
+  }
+  else{
+    std::cout << RWtoPub << " Not available for RWtoPub" << std::endl; 
+  }
 
   // grab the pre-parsed param headers object
   SystMetaData const &md = GetSystMetaData();
@@ -204,10 +220,10 @@ bool ZExpPCAWeighter::SetupResponseCalculator(
       // md and the rotation function
       Eigen::VectorXd a_variations = ChangeBasisBParams(
           bvariations,
-          GetPCAFromCovarianceMatrix(Nature_614_102522::Covariance_Matrix));
+          GetPCAFromCovarianceMatrix(Covariance_Matrix));
 
       // Now use the b_variations to get the a values
-      auto myaparameters = ScaleAparamsforGenie(a_variations);
+      auto myaparameters = ScaleAparamsforGenie(a_14_cv, a_variations);
 
       if (verbosity_level > 2) {
         std::cout << "b[" << i << "] = " << v << std::endl;

--- a/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
+++ b/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
@@ -131,9 +131,19 @@ SystMetaData ZExpPCAWeighter::BuildSystMetaData(fhicl::ParameterSet const &ps,
   tool_options.put("verbosity_level",
                    ps.get<int>("verbosity_level",
                                0)); // put tool config options in papam geaders
-  tool_options.put("RWtoPub",
-                   ps.get<std::string>("RWtoPub",
-                               "PRD_93_113015")); // put tool config options in papam geaders
+
+  std::string RWtoPub = ps.get<std::string>("RWtoPub", "PRD_93_113015");
+  tool_options.put("RWtoPub", RWtoPub);
+
+  if(RWtoPub == "Nature_614_102522"){
+    tool_options.put("T0", -0.75);
+  }
+  else if(RWtoPub == "PRD_93_113015"){
+    tool_options.put("T0", -0.28);
+  }
+  else{
+    throw std::invalid_argument( "Invalid option for RWtoPub, please select Nature_614_102522 or PRD_93_113015" );
+  }
 
   return smd;
 }
@@ -162,6 +172,9 @@ bool ZExpPCAWeighter::SetupResponseCalculator(
     //std::cout << RWtoPub << " Not available for RWtoPub" << std::endl; 
     throw std::invalid_argument( "Invalid option for RWtoPub, please select Nature_614_102522 or PRD_93_113015" );
   }
+
+  if (tool_options.get_if_present("T0", fZExpT0)) fZExpOverrideT0 = true;
+  if (tool_options.get_if_present("Tcut", fZExpTcut)) fZExpOverrideTcut = true;
 
   // grab the pre-parsed param headers object
   SystMetaData const &md = GetSystMetaData();
@@ -242,6 +255,11 @@ bool ZExpPCAWeighter::SetupResponseCalculator(
         ReWeightEngines_new[i].back()->SetSystematic(zexp_dials[aval_j],
                                                      myaparameters[aval_j]);
       }
+
+      // set other Z-exp parameters
+      if (fZExpOverrideT0) ReWeightEngines_new[i].back()->SetZExpT0(fZExpT0);
+      if (fZExpOverrideTcut) ReWeightEngines_new[i].back()->SetZExpTcut(fZExpTcut);
+
       ReWeightEngines_new[i].back()->Reconfigure();
       if (verbosity_level > 2) {
         std::cout << "Done Reconfigure()" << std::endl;

--- a/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
+++ b/src/nusystematics/systproviders/ZExpPCAWeighter_tool.cc
@@ -43,6 +43,19 @@ Eigen::Array4d central_values_afrom_errors_genie_code = {0.14, 0.67, 1,
 Eigen::Array4d central_values_afrom_errors_genie = {0.13, 1, 2.5, 2.7};
 } // namespace PRD_93_113015
 
+namespace Nature_614_102522 {
+Eigen::Vector4d a_14_cv{1.50, -1.2, -0.1, 0.2};
+Eigen::Vector4d a_14_errors{0.31, 0.7, 1.9, 2.5};
+Eigen::MatrixXd Covariance_Matrix{{0.0961, 0.002604, -0.54777, 0.403},
+                                  {0.002604, 0.49, -0.4256, -1.365},
+                                  {-0.54777, -0.4256, 3.61, -1.2825},
+                                  {0.403, -1.365, -1.2825, 6.25}};
+Eigen::Array4d central_values_a_from_genie = {2.30, -0.60, -3.80, 2.30};
+Eigen::Array4d central_values_afrom_errors_genie_code = {0.14, 0.67, 1,
+                                                         0.75}; //-----in genie
+Eigen::Array4d central_values_afrom_errors_genie = {0.13, 1, 2.5, 2.7};
+} // namespace Nature_614_102522
+
 Eigen::MatrixXd
 GetPCAFromCovarianceMatrix(Eigen::MatrixXd const &Covariance_Matrix) {
   Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(Covariance_Matrix);
@@ -70,10 +83,10 @@ Eigen::VectorXd ChangeBasisBParams(std::vector<double> const &BVals,
 // Function to rescale the a parameters for GENIE ReWeight
 Eigen::Array4d ScaleAparamsforGenie(Eigen::VectorXd &avals) {
   Eigen::VectorXd avalues_for_genie =
-      (((PRD_93_113015::a_14_cv + avals).array() /
-        PRD_93_113015::central_values_a_from_genie.array()) -
+      (((Nature_614_102522::a_14_cv + avals).array() /
+        Nature_614_102522::central_values_a_from_genie.array()) -
        1.0) /
-      PRD_93_113015::central_values_afrom_errors_genie_code.array();
+      Nature_614_102522::central_values_afrom_errors_genie_code.array();
   return avalues_for_genie;
 }
 
@@ -89,11 +102,11 @@ ZExpPCAWeighter::ZExpPCAWeighter(
     : IGENIESystProvider_tool(
           params), // IGENIESystProvider_tool takes parameters and sets tune and
                    // event records etc. in GENIE
+                   //
       pidx_Params{kParamUnhandled<size_t>, kParamUnhandled<size_t>,
                   kParamUnhandled<size_t>, kParamUnhandled<size_t>} {
 } // The ParamHeaders id of the four free parameters provided by
   // thissystprovider
-
 SystMetaData ZExpPCAWeighter::BuildSystMetaData(fhicl::ParameterSet const &ps,
                                                 paramId_t firstId) {
   SystMetaData smd;
@@ -127,6 +140,8 @@ SystMetaData ZExpPCAWeighter::BuildSystMetaData(fhicl::ParameterSet const &ps,
 bool ZExpPCAWeighter::SetupResponseCalculator(
     fhicl::ParameterSet const &tool_options) {
   verbosity_level = tool_options.get<int>("verbosity_level", 0);
+  std::string RwtoPub = tool_options.get<std::string>("RWtoPub", "PRD_93_113015");
+  std::cout << "Found RwtoPub: " << RwtoPub << std::endl;
 
   // grab the pre-parsed param headers object
   SystMetaData const &md = GetSystMetaData();
@@ -189,7 +204,7 @@ bool ZExpPCAWeighter::SetupResponseCalculator(
       // md and the rotation function
       Eigen::VectorXd a_variations = ChangeBasisBParams(
           bvariations,
-          GetPCAFromCovarianceMatrix(PRD_93_113015::Covariance_Matrix));
+          GetPCAFromCovarianceMatrix(Nature_614_102522::Covariance_Matrix));
 
       // Now use the b_variations to get the a values
       auto myaparameters = ScaleAparamsforGenie(a_variations);

--- a/src/nusystematics/systproviders/ZExpPCAWeighter_tool.hh
+++ b/src/nusystematics/systproviders/ZExpPCAWeighter_tool.hh
@@ -63,4 +63,10 @@ private:
   // configurable verbosity as an example of some arbitrary systprovider
   // configuration
   int verbosity_level;
+
+  bool    fZExpOverrideT0; ///< whether to override T0 value in z expansion
+  double  fZExpT0; ///< T0 override value
+  bool    fZExpOverrideTcut; ///< whether to override Tcut value in z expansion
+  double  fZExpTcut; ///< Tcut override value
+
 };


### PR DESCRIPTION
This PR does two things:

- Adds information from MINERvA Z-Expansion result: https://www.nature.com/articles/s41586-022-05478-3
- Makes the selection of Z-Expansion results configurable using fcl parameters.