### PR TITLE
# NEW: apply only in this q0 window

### DIFF
--- a/fcl/SuSAv2_MEC_reweight.ToolConfig.fcl
+++ b/fcl/SuSAv2_MEC_reweight.ToolConfig.fcl
@@ -14,8 +14,12 @@ MECInterp: {
     # MODEL SELECTION: Choose "valencia" or "martini"
     # File paths are auto-generated based on Model and DataBaseDir
     # No need to manually specify np_files/nn_files anymore!
+    #
+    # Physics coverage:
+    #   Valencia: q0 <= 1.2 GeV, q3 <= 1.2 GeV (both limited)
+    #   Martini:  q0 <= 0.995 GeV (limited), q3 <= ~2.0 GeV (good)
     # ============================================================
-    Model: "valencia"  # Options: "valencia" or "martini"
+    Model: "martini"  # Options: "valencia" or "martini"
     
     # Base data directory
     DataBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/data"
@@ -30,8 +34,16 @@ MECInterp: {
     WeightLimits : [0.1, 1000.0]
 
     # NEW: apply only in this q0 window
+    # Valencia: q0 up to 1.2 GeV
+    # Martini:  q0 up to 0.995 GeV
     Q0ApplyMin: 0.0     # GeV
-    Q0ApplyMax: 3.0     # GeV
+    Q0ApplyMax: 0.995     # GeV (Valencia: 1.2, Martini: 0.995)
+
+    # NEW: apply only in this q3 window
+    # Valencia: q3 up to 1.2 GeV (limited)
+    # Martini:  q3 up to ~2.0 GeV (good coverage, use 3.0 for no limit)
+    Q3ApplyMin: 0.0     # GeV
+    Q3ApplyMax: 2.0     # GeV (Valencia: 1.2, Martini: 2.0)
 
     Q0GuardMin: 0.0            
 
@@ -57,6 +69,25 @@ MECInterp: {
   # instead of extrapolating or using empty bins. Enabling this reduces
   # large discontinuities and suppresses artificial peaks at the edges.
   EdgeClamp: true
+
+  # OutOfRangeWeight: weight to return for events outside histogram bounds.
+  # Default behavior (auto-determined by Model):
+  #   - valencia: 0.0 (suppress events beyond histogram range)
+  #   - martini:  0.0 (suppress events beyond histogram range)
+  #   - custom:   1.0 (keep original prediction, backward compatible)
+  # Explicitly set to override auto-detection:
+  OutOfRangeWeight: 0.0
+
+  # IMPORTANT: OutOfRangeWeight applies to events outside HISTOGRAM bounds.
+  # For physics-based cutoffs, use Q0ApplyMax/Q3ApplyMax above:
+  #
+  # Valencia limits (both q0 and q3 limited to 1.2 GeV):
+  #   Q0ApplyMax: 1.2  ->  weight=1.0 for q0>=1.2 GeV
+  #   Q3ApplyMax: 1.2  ->  weight=1.0 for q3>=1.2 GeV
+  #
+  # Martini limits (q0 limited to 0.995 GeV, q3 good to ~2.0 GeV):
+  #   Q0ApplyMax: 0.995  ->  weight=1.0 for q0>=0.995 GeV
+  #   Q3ApplyMax: 3.0    ->  effectively no q3 limit (Martini has good coverage)
 
   }
 

--- a/src/nusystematics/responsecalculators/MECq0q3ResponseCalc.hh
+++ b/src/nusystematics/responsecalculators/MECq0q3ResponseCalc.hh
@@ -25,6 +25,7 @@ public:
 
   void   SetUseNearestBin(bool v) { fUseNearestBin = v; }
   void   SetEdgeClamp(bool v)     { fEdgeClamp = v; }
+  void   SetOutOfRangeWeight(double w) { fOutOfRangeWeight = w; }
 
 private:
   std::unique_ptr<TH2D> fHist;   ///< owned, thread‑safe clone of the histogram
@@ -32,6 +33,7 @@ private:
   bool   fMapIsQ3xQ0{false};           ///< true if map is in (q3, q0) coordinates
   bool   fUseNearestBin{false};   ///< default off → legacy bilinear
   bool   fEdgeClamp{false};       ///< default off → legacy out-of-range=1
+  double fOutOfRangeWeight{1.0};  ///< weight to return when outside histogram bounds (default 1.0 for backward compatibility, set to 0.0 to suppress)
 };
 
 // ---------------------------------------------------------------------------
@@ -71,16 +73,16 @@ inline double MECq0q3ResponseCalc::GetCentralWeight(double q0, double q3) const
     // --- piecewise-constant: nearest-bin content ---
     int ix = fHist->GetXaxis()->FindBin(q3);
     int iy = fHist->GetYaxis()->FindBin(q0);
-    // clamp to valid bins (1..Nbins) if requested, else treat OOR as unity
+    // clamp to valid bins (1..Nbins) if requested, else treat OOR as configurable
     if (!in_x || !in_y) {
-      if (!fEdgeClamp) return 1.0;
+      if (!fEdgeClamp) return fOutOfRangeWeight;
       ix = std::clamp(ix, 1, fHist->GetNbinsX());
       iy = std::clamp(iy, 1, fHist->GetNbinsY());
     }
     w = fHist->GetBinContent(ix, iy);
   } else {
-    // --- legacy: bilinear interpolation inside domain; 1.0 outside ---
-    if (!in_x || !in_y) return 1.0;
+    // --- legacy: bilinear interpolation inside domain; configurable weight outside ---
+    if (!in_x || !in_y) return fOutOfRangeWeight;
     w = fHist->Interpolate(q3, q0);
   }
   return clamp(w, fWmin, fWmax);

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -320,22 +320,20 @@ MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
     return this->GetDefaultEventResponse();
 
   // Helper lambda to create zero-weight response (suppress events)
+
   auto GetZeroWeightResponse = [this]() {
-    systtools::event_unit_response_t response;
-    if (!this->GetSystMetaData().empty()) {
-      const auto &hdr = this->GetSystMetaData()[0];
-      systtools::ParamResponses pr;
-      pr.pid = hdr.systParamId;
-      pr.responses.assign(hdr.paramVariations.size(), 0.0);
-      if (pr.responses.empty()) pr.responses.push_back(0.0);
-      response.push_back(std::move(pr));
-    } else {
-      systtools::ParamResponses pr;
-      pr.pid = 0;
-      pr.responses = { 0.0 };
-      response.push_back(std::move(pr));
+    auto const& smd = this->GetSystMetaData();
+    systtools::event_unit_response_t resp;
+    resp.reserve(smd.size());
+    for(auto const& sph : smd) {
+      // Create zero-weight response for this parameter
+      if (sph.isCorrection) {
+        resp.push_back({sph.systParamId, std::vector<double>{0.0}});
+      } else {
+        resp.push_back({sph.systParamId, std::vector<double>(sph.paramVariations.size(), 0.0)});
+      }
     }
-    return response;
+    return resp;
   };
 
   // NEW: q0 apply window gate: ZERO weight if outside (q0min, q0max)

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -101,6 +101,20 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
   if (!(fQ0ApplyMax > fQ0ApplyMin))
     throw std::runtime_error("Q0ApplyMax must be > Q0ApplyMin");
 
+  // NEW: q3 apply window (optional, defaults to [0, +inf))
+  fQ3ApplyMin = manifest.get<double>("Q3ApplyMin", 0.0);
+  if (manifest.has_key("Q3ApplyMax")) {
+    fQ3ApplyMax = manifest.get<double>("Q3ApplyMax");
+    if (!(std::isfinite(fQ3ApplyMax)))
+      throw std::runtime_error("Q3ApplyMax must be finite if provided");
+  } else {
+    fQ3ApplyMax = std::numeric_limits<double>::infinity();
+  }
+  if (!(std::isfinite(fQ3ApplyMin) && fQ3ApplyMin >= 0.0))
+    throw std::runtime_error("Q3ApplyMin must be finite and >= 0");
+  if (!(fQ3ApplyMax > fQ3ApplyMin))
+    throw std::runtime_error("Q3ApplyMax must be > Q3ApplyMin");
+
 
 
 
@@ -128,9 +142,28 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
   const bool mapIsQ3xQ0 = manifest.get<bool>("MapIsQ3xQ0", false);
   const bool useNearestBin = manifest.get<bool>("UseNearestBin", true);  // turn ON new behavior
   const bool edgeClamp     = manifest.get<bool>("EdgeClamp",     true);  // clamp OOR to edge bin
+  
+  // Read Model parameter early to determine default out-of-range behavior
+  std::string model = manifest.get<std::string>("Model", "");
+  
+  // Out-of-range weight: default depends on model
+  // Valencia: 0.0 (suppress beyond q3~1.2 GeV, q0~??? GeV)
+  // Martini:  0.0 (suppress beyond q0~0.995 GeV)
+  // Custom:   configurable via OutOfRangeWeight parameter
+  double outOfRangeWeight = 1.0;  // backward compatible default
+  if (manifest.has_key("OutOfRangeWeight")) {
+    outOfRangeWeight = manifest.get<double>("OutOfRangeWeight");
+  } else if (!model.empty()) {
+    // Auto-set based on model to match native generator behavior
+    if (model == "valencia" || model == "martini") {
+      outOfRangeWeight = 0.0;  // Suppress events outside model's phase space
+    }
+  }
+  
   std::cout << "  MapIsQ3xQ0     : " << (mapIsQ3xQ0 ? "true" : "false") << "\n";
   std::cout << "  UseNearestBin  : " << (useNearestBin ? "true" : "false") << "\n";
   std::cout << "  EdgeClamp      : " << (edgeClamp ? "true" : "false") << "\n";
+  std::cout << "  OutOfRangeWeight: " << outOfRangeWeight << "\n";
 
 
 
@@ -149,8 +182,7 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
   //  (B) Arrays np_files/nn_files with explicit histogram names: HistNameNP/HistNameNN
   //  (C) Auto-generate file paths based on Model parameter
   
-  // NEW: Check for Model parameter to auto-select file paths
-  std::string model = manifest.get<std::string>("Model", "");
+  // Read DataBaseDir for auto-generation (model already read earlier for outOfRangeWeight)
   std::string dataBaseDir = manifest.get<std::string>("DataBaseDir", "");
   
   std::vector<std::string> np_files, nn_files;
@@ -222,6 +254,7 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
         auto calc = std::make_unique<MECq0q3ResponseCalc>(h, fWmin, fWmax, mapIsQ3xQ0);
         calc->SetUseNearestBin(useNearestBin);
         calc->SetEdgeClamp(edgeClamp);
+        calc->SetOutOfRangeWeight(outOfRangeWeight);
         vec.emplace_back(std::move(calc));
       }
     }
@@ -254,6 +287,7 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
         auto calc = std::make_unique<MECq0q3ResponseCalc>(h, fWmin, fWmax, mapIsQ3xQ0);
         calc->SetUseNearestBin(useNearestBin);
         calc->SetEdgeClamp(edgeClamp);
+        calc->SetOutOfRangeWeight(outOfRangeWeight);
         vec.emplace_back(std::move(calc));
         fin.Close();
       }
@@ -285,9 +319,32 @@ MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
   if (Enu < fEnuMin - 1e-6 || Enu > fEnuMax + 1e-6)
     return this->GetDefaultEventResponse();
 
-  // NEW: q0 apply window gate: unity if outside (q0min, q0max)
+  // Helper lambda to create zero-weight response (suppress events)
+  auto GetZeroWeightResponse = [this]() {
+    systtools::event_unit_response_t response;
+    if (!this->GetSystMetaData().empty()) {
+      const auto &hdr = this->GetSystMetaData()[0];
+      systtools::ParamResponses pr;
+      pr.pid = hdr.systParamId;
+      pr.responses.assign(hdr.paramVariations.size(), 0.0);
+      if (pr.responses.empty()) pr.responses.push_back(0.0);
+      response.push_back(std::move(pr));
+    } else {
+      systtools::ParamResponses pr;
+      pr.pid = 0;
+      pr.responses = { 0.0 };
+      response.push_back(std::move(pr));
+    }
+    return response;
+  };
+
+  // NEW: q0 apply window gate: ZERO weight if outside (q0min, q0max)
   if (q0 <= fQ0ApplyMin + 1e-6 || q0 >= fQ0ApplyMax - 1e-6)
-    return this->GetDefaultEventResponse();
+    return GetZeroWeightResponse();
+
+  // NEW: q3 apply window gate: ZERO weight if outside (q3min, q3max)
+  if (q3 <= fQ3ApplyMin + 1e-6 || q3 >= fQ3ApplyMax - 1e-6)
+    return GetZeroWeightResponse();
 
 
   // q0 guard: unity below Min (inclusive with epsilon)

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.hh
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.hh
@@ -52,6 +52,11 @@ private:
   double fQ0ApplyMin{0.0};                                   // GeV
   double fQ0ApplyMax{std::numeric_limits<double>::infinity()}; // GeV
 
+  // NEW: q3 apply window (gate). Weighting applies only if
+  //      fQ3ApplyMin < q3 < fQ3ApplyMax. Defaults: [0, +inf)
+  double fQ3ApplyMin{0.0};                                   // GeV
+  double fQ3ApplyMax{std::numeric_limits<double>::infinity()}; // GeV
+
   // Ramp guard: unity below Min; linear blend to full weight by Max
   // If Max == Min, behaves like a hard cutoff at Min
   double fQ0GuardMin{0.0};  // GeV


### PR DESCRIPTION
    # Valencia: q0 up to 1.2 GeV
    # Martini:  q0 up to 0.995 GeV
    Q0ApplyMin: 0.0     # GeV
    Q0ApplyMax: 0.995     # GeV (Valencia: 1.2, Martini: 0.995)

    # NEW: apply only in this q3 window
    # Valencia: q3 up to 1.2 GeV (limited)
    # Martini:  q3 up to ~2.0 GeV (good coverage, use 3.0 for no limit)
    Q3ApplyMin: 0.0     # GeV
    Q3ApplyMax: 2.0     # GeV (Valencia: 1.2, Martini: 2.0)      making sure that out of theis ranges there is a weight 0 applied