### PR TITLE
When Q0 selection is ENABLED (Q0SelectMax > 0): Events outside the Q3ApplyMin/Q0ApplyMin/Q3ApplyMax/Q0ApplyMax region will receive weight = 1

### DIFF
--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned.ToolConfig.fcl
@@ -52,7 +52,7 @@ SuSAv2ToMartini_MECInterp_q0binned: {
     # 
     # Events outside all bins receive weight=1.0 (no reweighting)
     # ============================================================
-    Q0Bins: [0.0, 0.2, 0.4, 0.6, 1.0]  # GeV
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
 
     # Full energy grid (0.4 to 2.5 GeV, 0.05 GeV step)
     EnergyGrid : [ 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned.ToolConfig.fcl
@@ -1,0 +1,90 @@
+SuSAv2ToMartini_MECInterp_q0binned: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToMartini_q0binned"
+
+  # ============================================================
+  # Q0-BINNED MODE: Multiple independent dials per q0 bin
+  # 
+  # This configuration creates 4 independent dials:
+  #   dial0: q0 [0.0, 0.2) GeV
+  #   dial1: q0 [0.2, 0.4) GeV
+  #   dial2: q0 [0.4, 0.6) GeV
+  #   dial3: q0 [0.6, 1.0) GeV
+  #
+  # EFFICIENCY: Weight templates are read ONCE and shared across
+  # all dials. Each event activates only the dial for its q0 bin.
+  # ============================================================
+
+  # Define multiple q0-binned dials (one per bin)
+  MECResponse_q0bin0_central_value: 0
+  MECResponse_q0bin0_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin1_central_value: 0
+  MECResponse_q0bin1_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin2_central_value: 0
+  MECResponse_q0bin2_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin3_central_value: 0
+  MECResponse_q0bin3_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL SELECTION
+    # ============================================================
+    Model: "martini"  # Options: "valencia" or "martini"
+    
+    # Base data directory
+    DataBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/data"
+
+    # ============================================================
+    # Q0 BINNING: Define bin edges for multiple dials
+    # Format: [edge0, edge1, edge2, ..., edgeN]
+    # Creates N-1 bins: [edge0,edge1), [edge1,edge2), ..., [edgeN-1,edgeN]
+    # 
+    # Example: [0.0, 0.2, 0.4, 0.6, 1.0] creates 4 bins:
+    #   bin0: [0.0, 0.2)  -> dial MECResponse_q0bin0
+    #   bin1: [0.2, 0.4)  -> dial MECResponse_q0bin1
+    #   bin2: [0.4, 0.6)  -> dial MECResponse_q0bin2
+    #   bin3: [0.6, 1.0]  -> dial MECResponse_q0bin3
+    # 
+    # Events outside all bins receive weight=1.0 (no reweighting)
+    # ============================================================
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 1.0]  # GeV
+
+    # Full energy grid (0.4 to 2.5 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,
+                   1.0, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55,
+                   1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2.0, 2.05, 2.1, 2.15,
+                   2.2, 2.25, 2.3, 2.35, 2.4, 2.45, 2.5 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # Apply window for q0 and q3 (outside these ranges, weight=1.0)
+    # Martini: q0 up to 0.995 GeV, q3 up to ~2.0 GeV
+    Q0ApplyMin: 0.0
+    Q0ApplyMax: 0.995
+    Q3ApplyMin: 0.0
+    Q3ApplyMax: 2.0
+
+    # Energy window
+    EnuMin:       0.4
+    EnuMax:       2.5
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    UseNearestBin: false
+    EdgeClamp: true
+    OutOfRangeWeight: 0.0
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToMartini_MECInterp_q0binned]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight.ToolConfig.fcl
@@ -3,6 +3,13 @@ SuSAv2ToMartini_MECInterp: {
   tool_type: "MECq0q3InterpWeighting"
   instance_name: "SuSAv2ToMartini"
 
+  # ============================================================
+  # SINGLE-DIAL MODE
+  # This configuration uses ONE dial that applies to all events.
+  # For multiple q0-binned dials, see:
+  #   SuSAv2ToMartini_MEC_q0binned.ToolConfig.fcl
+  # ============================================================
+
   # Define the systematic parameter (dial) for interpolation weighting
   # central value 0, evaluate at -1, 0, +1 (can expand later)
   MECResponse_central_value: 0
@@ -45,11 +52,15 @@ SuSAv2ToMartini_MECInterp: {
     Q3ApplyMin: 0.0     # GeV
     Q3ApplyMax: 2.0     # GeV (Valencia: 1.2, Martini: 2.0)
 
-    # NEW: Q0 selection range (fine-grained control)
+    # Q0 selection range (SINGLE-DIAL MODE ONLY)
     # If both are 0, selection is disabled and reweighting applies to all q0
     # If set, reweighting is applied ONLY in this range; outside it, weight=1
     # Example: Q0SelectMin: 0.05, Q0SelectMax: 0.1  -> reweight only 0.05-0.1 GeV
     # This is independent of Q0ApplyMin/Q0ApplyMax above
+    # 
+    # NOTE: For multiple q0 bins with separate dials, use Q0Bins instead.
+    #       See SuSAv2ToMartini_MEC_q0binned.ToolConfig.fcl for example.
+    #       Q0SelectMin/Max is ignored when Q0Bins is set.
     Q0SelectMin: 0.0    # GeV (0.0 = disabled)
     Q0SelectMax: 0.0    # GeV (0.0 = disabled)
 

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight.ToolConfig.fcl
@@ -53,7 +53,7 @@ SuSAv2ToMartini_MECInterp: {
     Q0SelectMin: 0.0    # GeV (0.0 = disabled)
     Q0SelectMax: 0.0    # GeV (0.0 = disabled)
 
-  EnuMin:       0.4
+    EnuMin:       0.4
     EnuMax:       2.5
     EnuSnapTol:   0.005
 

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned.ToolConfig.fcl
@@ -52,7 +52,7 @@ SuSAv2ToValenica_MECInterp_q0binned: {
     # 
     # Events outside all bins receive weight=1.0 (no reweighting)
     # ============================================================
-    Q0Bins: [0.0, 0.2, 0.4, 0.6, 1.0]  # GeV
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
 
     # Full energy grid (0.4 to 2.5 GeV, 0.05 GeV step)
     EnergyGrid : [ 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned.ToolConfig.fcl
@@ -1,0 +1,90 @@
+SuSAv2ToValenica_MECInterp_q0binned: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToValenica_q0binned"
+
+  # ============================================================
+  # Q0-BINNED MODE: Multiple independent dials per q0 bin
+  # 
+  # This configuration creates 4 independent dials:
+  #   dial0: q0 [0.0, 0.2) GeV
+  #   dial1: q0 [0.2, 0.4) GeV
+  #   dial2: q0 [0.4, 0.6) GeV
+  #   dial3: q0 [0.6, 1.0) GeV
+  #
+  # EFFICIENCY: Weight templates are read ONCE and shared across
+  # all dials. Each event activates only the dial for its q0 bin.
+  # ============================================================
+
+  # Define multiple q0-binned dials (one per bin)
+  MECResponse_q0bin0_central_value: 0
+  MECResponse_q0bin0_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin1_central_value: 0
+  MECResponse_q0bin1_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin2_central_value: 0
+  MECResponse_q0bin2_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin3_central_value: 0
+  MECResponse_q0bin3_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL SELECTION
+    # ============================================================
+    Model: "valencia"  # Options: "valencia" or "martini"
+    
+    # Base data directory
+    DataBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/data"
+
+    # ============================================================
+    # Q0 BINNING: Define bin edges for multiple dials
+    # Format: [edge0, edge1, edge2, ..., edgeN]
+    # Creates N-1 bins: [edge0,edge1), [edge1,edge2), ..., [edgeN-1,edgeN]
+    # 
+    # Example: [0.0, 0.2, 0.4, 0.6, 1.0] creates 4 bins:
+    #   bin0: [0.0, 0.2)  -> dial MECResponse_q0bin0
+    #   bin1: [0.2, 0.4)  -> dial MECResponse_q0bin1
+    #   bin2: [0.4, 0.6)  -> dial MECResponse_q0bin2
+    #   bin3: [0.6, 1.0]  -> dial MECResponse_q0bin3
+    # 
+    # Events outside all bins receive weight=1.0 (no reweighting)
+    # ============================================================
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 1.0]  # GeV
+
+    # Full energy grid (0.4 to 2.5 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,
+                   1.0, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55,
+                   1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2.0, 2.05, 2.1, 2.15,
+                   2.2, 2.25, 2.3, 2.35, 2.4, 2.45, 2.5 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # Apply window for q0 and q3 (outside these ranges, weight=1.0)
+    # Valencia: q0 up to 1.2 GeV, q3 up to 1.2 GeV (both limited)
+    Q0ApplyMin: 0.0
+    Q0ApplyMax: 1.2
+    Q3ApplyMin: 0.0
+    Q3ApplyMax: 1.2
+
+    # Energy window
+    EnuMin:       0.4
+    EnuMax:       2.5
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    UseNearestBin: false
+    EdgeClamp: true
+    OutOfRangeWeight: 0.0
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToValenica_MECInterp_q0binned]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight.ToolConfig.fcl
@@ -53,7 +53,7 @@ SuSAv2ToValenica_MECInterp: {
     Q0SelectMin: 0.0    # GeV (0.0 = disabled)
     Q0SelectMax: 0.0    # GeV (0.0 = disabled)
 
-  EnuMin:       0.4
+    EnuMin:       0.4
     EnuMax:       2.5
     EnuSnapTol:   0.005
 

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight.ToolConfig.fcl
@@ -3,6 +3,12 @@ SuSAv2ToValenica_MECInterp: {
   tool_type: "MECq0q3InterpWeighting"
   instance_name: "SuSAv2ToValenica"
 
+  # ============================================================
+  # SINGLE-DIAL MODE
+  # This configuration uses ONE dial that applies to all events.
+  # For multiple q0-binned dials, see the q0binned example config.
+  # ============================================================
+
   # Define the systematic parameter (dial) for interpolation weighting
   # central value 0, evaluate at -1, 0, +1 (can expand later)
   MECResponse_central_value: 0
@@ -45,11 +51,14 @@ SuSAv2ToValenica_MECInterp: {
     Q3ApplyMin: 0.0     # GeV
     Q3ApplyMax: 1.2     # GeV (Valencia: 1.2, Martini: 2.0)
 
-    # NEW: Q0 selection range (fine-grained control)
+    # Q0 selection range (SINGLE-DIAL MODE ONLY)
     # If both are 0, selection is disabled and reweighting applies to all q0
     # If set, reweighting is applied ONLY in this range; outside it, weight=1
     # Example: Q0SelectMin: 0.05, Q0SelectMax: 0.1  -> reweight only 0.05-0.1 GeV
     # This is independent of Q0ApplyMin/Q0ApplyMax above
+    # 
+    # NOTE: For multiple q0 bins with separate dials, use Q0Bins instead.
+    #       Q0SelectMin/Max is ignored when Q0Bins is set.
     Q0SelectMin: 0.0    # GeV (0.0 = disabled)
     Q0SelectMax: 0.0    # GeV (0.0 = disabled)
 

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -378,21 +378,23 @@ MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
     return resp;
   };
 
-  // Determine if Q0 selection range is enabled
+  // Determine if Q0 selection/binning is enabled
+  // Either Q0SelectMin/Max OR Q0Bins means we want weight=1 outside apply windows
   const bool q0SelectionEnabled = (fQ0SelectMax > 0.0);
+  const bool q0BinningEnabled = (!fQ0Bins.empty());
 
   // NEW: q3/q0 apply window gate logic
-  // If Q0 selection is ENABLED: return weight=1 if outside apply windows
-  // If Q0 selection is DISABLED: return weight=0 if outside apply windows
+  // If Q0 selection OR Q0 binning is ENABLED: return weight=1 if outside apply windows
+  // If BOTH are DISABLED: return weight=0 if outside apply windows
   const bool outsideQ3Apply = (q3 <= fQ3ApplyMin + 1e-6 || q3 >= fQ3ApplyMax - 1e-6);
   const bool outsideQ0Apply = (q0 <= fQ0ApplyMin + 1e-6 || q0 >= fQ0ApplyMax - 1e-6);
   
   if (outsideQ3Apply || outsideQ0Apply) {
-    if (q0SelectionEnabled) {
-      // When Q0 selection is enabled, return weight=1 outside apply region
+    if (q0SelectionEnabled || q0BinningEnabled) {
+      // When Q0 selection or binning is enabled, return weight=1 outside apply region
       return this->GetDefaultEventResponse();
     } else {
-      // When Q0 selection is disabled, return weight=0 outside apply region
+      // When both are disabled, return weight=0 outside apply region
       return GetZeroWeightResponse();
     }
   }

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -43,16 +43,39 @@ MECq0q3InterpWeighting::BuildSystMetaData(fhicl::ParameterSet const &ps,
   std::cout << "[MECq0q3InterpWeighting::BuildSystMetaData] Called\n";
 
   SystMetaData smd;
-  SystParamHeader phdr;
-  if (ParseFhiclToolConfigurationParameter(ps,
-                                           "MECResponse",
-                                           phdr, firstId)) {
-    phdr.systParamId = firstId++;
-    smd.push_back(phdr);
+  
+  // Check if Q0 binning is enabled
+  auto man = ps.get<fhicl::ParameterSet>("MECResponse_input_manifest");
+  std::vector<double> q0Bins;
+  if (man.has_key("Q0Bins")) {
+    q0Bins = man.get<std::vector<double>>("Q0Bins");
+  }
+  
+  // If Q0 binning is enabled, create multiple dials (one per bin)
+  if (!q0Bins.empty() && q0Bins.size() >= 2) {
+    std::cout << "  Q0-binned mode: creating " << (q0Bins.size() - 1) << " dials\n";
+    
+    for (size_t i = 0; i < q0Bins.size() - 1; ++i) {
+      std::string dialName = "MECResponse_q0bin" + std::to_string(i);
+      SystParamHeader phdr;
+      if (ParseFhiclToolConfigurationParameter(ps, dialName, phdr, firstId)) {
+        phdr.systParamId = firstId++;
+        smd.push_back(phdr);
+        std::cout << "    Created dial: " << dialName 
+                  << " for q0 [" << q0Bins[i] << ", " << q0Bins[i+1] << ") GeV\n";
+      }
+    }
+  } else {
+    // Single dial mode (backward compatible)
+    std::cout << "  Single-dial mode (backward compatible)\n";
+    SystParamHeader phdr;
+    if (ParseFhiclToolConfigurationParameter(ps, "MECResponse", phdr, firstId)) {
+      phdr.systParamId = firstId++;
+      smd.push_back(phdr);
+    }
   }
 
   // stash manifest for SetupResponseCalculator
-  auto man = ps.get<fhicl::ParameterSet>("MECResponse_input_manifest");
   tool_options.put("MECResponse_input_manifest", man);
 
   return smd;
@@ -114,6 +137,32 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
     throw std::runtime_error("Q3ApplyMin must be finite and >= 0");
   if (!(fQ3ApplyMax > fQ3ApplyMin))
     throw std::runtime_error("Q3ApplyMax must be > Q3ApplyMin");
+
+  // NEW: Q0 binning for multiple dials (optional)
+  if (manifest.has_key("Q0Bins")) {
+    fQ0Bins = manifest.get<std::vector<double>>("Q0Bins");
+    if (fQ0Bins.size() < 2)
+      throw std::runtime_error("Q0Bins must have at least 2 edges to define bins");
+    
+    // Validate bins are in ascending order
+    for (size_t i = 1; i < fQ0Bins.size(); ++i) {
+      if (fQ0Bins[i] <= fQ0Bins[i-1])
+        throw std::runtime_error("Q0Bins must be in strictly ascending order");
+    }
+    
+    std::cout << "  Q0 binning enabled: " << (fQ0Bins.size() - 1) << " bins\n";
+    std::cout << "  Bin edges:";
+    for (double edge : fQ0Bins) std::cout << " " << edge;
+    std::cout << " GeV\n";
+    
+    // Q0Select range incompatible with Q0Bins (they serve different purposes)
+    if (manifest.has_key("Q0SelectMin") || manifest.has_key("Q0SelectMax")) {
+      std::cout << "  WARNING: Q0SelectMin/Max ignored when Q0Bins is set\n";
+    }
+  } else {
+    // Single dial mode - legacy Q0 selection range still works
+    fQ0Bins.clear();
+  }
 
   // NEW: Q0 selection range (optional, defaults to disabled)
   fQ0SelectMin = manifest.get<double>("Q0SelectMin", 0.0);
@@ -393,22 +442,60 @@ MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
 
   // Build response vector
   systtools::event_unit_response_t response;
-  if (!this->GetSystMetaData().empty()) {
-    const auto &hdr = this->GetSystMetaData()[0];
-    systtools::ParamResponses pr;
-    pr.pid = hdr.systParamId;
-    pr.responses.reserve(hdr.paramVariations.size());
-    for (double d : hdr.paramVariations) {
-      const double rw = std::clamp(1.0 + d * one_sigma, fWmin, fWmax);
-      pr.responses.push_back(rw);
+  
+  // Q0-binned mode: multiple dials, only one active per event
+  if (!fQ0Bins.empty()) {
+    const int q0BinIdx = GetQ0BinIndex(q0);
+    const auto& smd = this->GetSystMetaData();
+    
+    // Build response for all dials
+    for (size_t dialIdx = 0; dialIdx < smd.size(); ++dialIdx) {
+      const auto& hdr = smd[dialIdx];
+      systtools::ParamResponses pr;
+      pr.pid = hdr.systParamId;
+      pr.responses.reserve(hdr.paramVariations.size());
+      
+      // If this event is in the current dial's q0 bin, use the calculated weight
+      // Otherwise, return weight=1.0 (no effect)
+      const bool isActiveDial = (static_cast<int>(dialIdx) == q0BinIdx);
+      
+      if (isActiveDial) {
+        // Apply reweighting for this dial
+        for (double d : hdr.paramVariations) {
+          const double rw = std::clamp(1.0 + d * one_sigma, fWmin, fWmax);
+          pr.responses.push_back(rw);
+        }
+        if (pr.responses.empty()) pr.responses.push_back(w_eff_cv);
+      } else {
+        // Inactive dial: return weight=1.0
+        for (size_t i = 0; i < hdr.paramVariations.size(); ++i) {
+          pr.responses.push_back(1.0);
+        }
+        if (pr.responses.empty()) pr.responses.push_back(1.0);
+      }
+      
+      response.push_back(std::move(pr));
     }
-    if (pr.responses.empty()) pr.responses.push_back(w_eff_cv);
-    response.push_back(std::move(pr));
-  } else {
-    systtools::ParamResponses pr;
-    pr.pid = 0;
-    pr.responses = { w_eff_cv };
-    response.push_back(std::move(pr));
+  } 
+  // Single dial mode (backward compatible)
+  else {
+    if (!this->GetSystMetaData().empty()) {
+      const auto &hdr = this->GetSystMetaData()[0];
+      systtools::ParamResponses pr;
+      pr.pid = hdr.systParamId;
+      pr.responses.reserve(hdr.paramVariations.size());
+      for (double d : hdr.paramVariations) {
+        const double rw = std::clamp(1.0 + d * one_sigma, fWmin, fWmax);
+        pr.responses.push_back(rw);
+      }
+      if (pr.responses.empty()) pr.responses.push_back(w_eff_cv);
+      response.push_back(std::move(pr));
+    } else {
+      systtools::ParamResponses pr;
+      pr.pid = 0;
+      pr.responses = { w_eff_cv };
+      response.push_back(std::move(pr));
+    }
   }
 
   return response;
@@ -447,4 +534,26 @@ MECq0q3InterpWeighting::ClassifyEvent(genie::EventRecord const& ev)
     if (pdg == genie::kPdgClusterNP) return Topo::np; // 1n+1p
   }
   return Topo::unknown;
+}
+
+// Determine which q0 bin (dial index) an event belongs to
+// Returns -1 if outside all bins
+int
+MECq0q3InterpWeighting::GetQ0BinIndex(double q0) const
+{
+  if (fQ0Bins.empty()) return 0;  // Single dial mode
+  
+  // Find the bin: [edge_i, edge_{i+1})
+  for (size_t i = 0; i < fQ0Bins.size() - 1; ++i) {
+    if (q0 >= fQ0Bins[i] && q0 < fQ0Bins[i+1]) {
+      return static_cast<int>(i);
+    }
+  }
+  
+  // Special case: include upper edge in the last bin
+  if (q0 == fQ0Bins.back()) {
+    return static_cast<int>(fQ0Bins.size() - 2);
+  }
+  
+  return -1;  // Outside all bins
 }

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -329,18 +329,28 @@ MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
     return resp;
   };
 
-  // NEW: q3 apply window gate: ZERO weight if outside (q3min, q3max) - CHECK BEFORE ENERGY GUARD
-  if (q3 <= fQ3ApplyMin + 1e-6 || q3 >= fQ3ApplyMax - 1e-6) {
-    return GetZeroWeightResponse();
-  }
+  // Determine if Q0 selection range is enabled
+  const bool q0SelectionEnabled = (fQ0SelectMax > 0.0);
 
-  // NEW: q0 apply window gate: ZERO weight if outside (q0min, q0max)
-  if (q0 <= fQ0ApplyMin + 1e-6 || q0 >= fQ0ApplyMax - 1e-6)
-    return GetZeroWeightResponse();
+  // NEW: q3/q0 apply window gate logic
+  // If Q0 selection is ENABLED: return weight=1 if outside apply windows
+  // If Q0 selection is DISABLED: return weight=0 if outside apply windows
+  const bool outsideQ3Apply = (q3 <= fQ3ApplyMin + 1e-6 || q3 >= fQ3ApplyMax - 1e-6);
+  const bool outsideQ0Apply = (q0 <= fQ0ApplyMin + 1e-6 || q0 >= fQ0ApplyMax - 1e-6);
+  
+  if (outsideQ3Apply || outsideQ0Apply) {
+    if (q0SelectionEnabled) {
+      // When Q0 selection is enabled, return weight=1 outside apply region
+      return this->GetDefaultEventResponse();
+    } else {
+      // When Q0 selection is disabled, return weight=0 outside apply region
+      return GetZeroWeightResponse();
+    }
+  }
 
   // NEW: Q0 selection range: weight=1 if outside the selected range (if enabled)
   // This allows fine-grained control: e.g., apply reweight only in 0.05 < q0 < 0.1 GeV
-  if (fQ0SelectMax > 0.0) {  // Selection is enabled
+  if (q0SelectionEnabled) {
     if (q0 < fQ0SelectMin - 1e-6 || q0 > fQ0SelectMax + 1e-6) {
       return this->GetDefaultEventResponse();  // weight=1 outside selection range
     }

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.hh
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.hh
@@ -64,6 +64,12 @@ private:
   double fQ0SelectMin{0.0};  // GeV
   double fQ0SelectMax{0.0};  // GeV
 
+  // NEW: Q0 binning for multiple dials
+  // If Q0Bins is provided, each bin gets its own dial
+  // Format: [edge0, edge1, edge2, ...] creates bins [edge0,edge1), [edge1,edge2), ...
+  // Empty vector means single dial mode (backward compatible)
+  std::vector<double> fQ0Bins;  // GeV bin edges
+  
   // Energy-guard window and snapping
   // Only energies within [fEnuMin, fEnuMax] are reweighted.
   // If |Enu - grid_point| <= fEnuSnapTol, use the exact map (no blending).
@@ -73,6 +79,10 @@ private:
 
   std::unordered_map<Topo,
       std::vector<std::unique_ptr<MECq0q3ResponseCalc>>> fCalcs;
+  
+  // Helper to determine which q0 bin (dial index) an event belongs to
+  // Returns -1 if outside all bins
+  int GetQ0BinIndex(double q0) const;
 };
 
 } // namespace nusyst


### PR DESCRIPTION
When Q0 selection is ENABLED (Q0SelectMax > 0): Events outside the Q3ApplyMin/Q0ApplyMin/Q3ApplyMax/Q0ApplyMax region will receive weight = 1
When Q0 selection is DISABLED (Q0SelectMax == 0): Events outside the apply region will receive weight = 0 as it is before the change.