### PR TITLE
Re-organizing AR25 FSI dials

### DIFF
--- a/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -473,22 +473,16 @@ ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
        kINukeTwkDial_FrAbs_N, kINukeTwkDial_FrPiProd_N},
       "INuke_N", []() { return new GReWeightINuke; }, UseFullHERG, param_map);
 
-/*
+  // Fates
   AddIndependentParameters(
-      QEmd, {kXSecTwkDial_VecFFCCQEshape}, "xsec_ccqe_vecFF",
-      []() { return new GReWeightNuXSecCCQEvec; }, UseFullHERG, param_map);
-*/
-
-  AddResponseAndDependentDials(
-      FSImd, "FSI_N_EDepVariationResponse",
-       {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,
+      FSImd, {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,
        kINukeTwkDial_G4LoE_N, kINukeTwkDial_INCLLoE_N,
        kINukeTwkDial_G4M1E_N, kINukeTwkDial_INCLM1E_N,
        kINukeTwkDial_G4M2E_N, kINukeTwkDial_INCLM2E_N,
        kINukeTwkDial_G4HiE_N, kINukeTwkDial_INCLHiE_N,
        kINukeTwkDial_MFPLoE_N, kINukeTwkDial_MFPM1E_N,
-       kINukeTwkDial_MFPM2E_N, kINukeTwkDial_MFPHiE_N},
-      "INuke_N_EDep", []() { return new GReWeightINukeExtra; }, UseFullHERG, param_map);
+       kINukeTwkDial_MFPM2E_N, kINukeTwkDial_MFPHiE_N}, "FrKin_FixPiPro",
+      []() { return new GReWeightINukeExtra; }, UseFullHERG, param_map);
 
   // Includes Bootstrapped (nucleon) Inelastic or Charge Exchange kinematics
   AddResponseAndDependentDials(

--- a/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -481,7 +481,7 @@ ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
        kINukeTwkDial_G4M2E_N, kINukeTwkDial_INCLM2E_N,
        kINukeTwkDial_G4HiE_N, kINukeTwkDial_INCLHiE_N,
        kINukeTwkDial_MFPLoE_N, kINukeTwkDial_MFPM1E_N,
-       kINukeTwkDial_MFPM2E_N, kINukeTwkDial_MFPHiE_N}, "FrKin_FixPiPro",
+       kINukeTwkDial_MFPM2E_N, kINukeTwkDial_MFPHiE_N}, "Fr_EDep_N",
       []() { return new GReWeightINukeExtra; }, UseFullHERG, param_map);
 
   // Includes Bootstrapped (nucleon) Inelastic or Charge Exchange kinematics

--- a/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -473,6 +473,12 @@ ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
        kINukeTwkDial_FrAbs_N, kINukeTwkDial_FrPiProd_N},
       "INuke_N", []() { return new GReWeightINuke; }, UseFullHERG, param_map);
 
+/*
+  AddIndependentParameters(
+      QEmd, {kXSecTwkDial_VecFFCCQEshape}, "xsec_ccqe_vecFF",
+      []() { return new GReWeightNuXSecCCQEvec; }, UseFullHERG, param_map);
+*/
+
   AddResponseAndDependentDials(
       FSImd, "FSI_N_EDepVariationResponse",
        {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,
@@ -484,11 +490,30 @@ ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
        kINukeTwkDial_MFPM2E_N, kINukeTwkDial_MFPHiE_N},
       "INuke_N_EDep", []() { return new GReWeightINukeExtra; }, UseFullHERG, param_map);
 
+  // Includes Bootstrapped (nucleon) Inelastic or Charge Exchange kinematics
   AddResponseAndDependentDials(
-      FSImd, "FSI_Kinematics", 
-      {kINukeKinematicsTwkDial_NP_N, kINukeKinematicsTwkDial_PP_N,
-       kINukeKinematicsFixPiPro, kINukeKinematicsPiProBias, kINukeKinematicsPiProBiaswFix}, 
+      FSImd, "FSI_Kinematics",
+      {kINukeKinematicsTwkDial_NP_N, kINukeKinematicsTwkDial_PP_N},
       "FrKin", []() { return new GReWeightINukeKinematics; }, UseFullHERG, param_map);
+
+  // If started with a sample without the hA-PiProd-bugfix,
+  // first we fix the CV
+  AddIndependentParameters(
+      FSImd, {kINukeKinematicsFixPiPro}, "FrKin_FixPiPro",
+      []() { return new GReWeightINukeKinematics; }, UseFullHERG, param_map);
+
+  // If started with a sample without the hA-PiProd-bugfix,
+  // a bias variation with the correction included?
+  AddIndependentParameters(
+      FSImd, {kINukeKinematicsPiProBias}, "FrKin_PiProBias",
+      []() { return new GReWeightINukeKinematics; }, UseFullHERG, param_map);
+
+
+  // If started with a sample with the hA-PiProd-bugfix,
+  // a bias variation 
+  AddIndependentParameters(
+      FSImd, {kINukeKinematicsPiProBiaswFix}, "FrKin_PiProBiaswFix",
+      []() { return new GReWeightINukeKinematics; }, UseFullHERG, param_map);
 
   return param_map;
 }

--- a/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -437,11 +437,35 @@ SystMetaData ConfigureFSIParameterHeaders(fhicl::ParameterSet const &cfg,
   firstParamId += FSI_N_EDep_md.size();
   ExtendSystMetaData(FSImd, std::move(FSI_N_EDep_md));
 
+  // Includes Bootstrapped (nucleon) Inelastic or Charge Exchange kinematics
   SystMetaData FSI_Kinematics = ConfigureSetOfDependentParameters(
       cfg, firstParamId, tool_options, "FSI_Kinematics",
-      {kINukeKinematicsTwkDial_NP_N, kINukeKinematicsTwkDial_PP_N, 
-       kINukeKinematicsFixPiPro, kINukeKinematicsPiProBias, kINukeKinematicsPiProBiaswFix}); 
+      {kINukeKinematicsTwkDial_NP_N, kINukeKinematicsTwkDial_PP_N});
   ExtendSystMetaData(FSImd, std::move(FSI_Kinematics));
+
+  // If started with a sample without the hA-PiProd-bugfix,
+  // first we fix the CV
+  SystMetaData FSI_Kinematrix_PiProFix_md = ConfigureSetOfIndependentParameters(
+      cfg, firstParamId,
+      {kINukeKinematicsFixPiPro});
+  firstParamId += FSI_Kinematrix_PiProFix_md.size();
+  ExtendSystMetaData(FSImd, std::move(FSI_Kinematrix_PiProFix_md));
+
+  // If started with a sample without the hA-PiProd-bugfix,
+  // a bias variation with the correction included?
+  SystMetaData FSI_Kinematrix_PiProBias_md = ConfigureSetOfIndependentParameters(
+      cfg, firstParamId,
+      {kINukeKinematicsPiProBias});
+  firstParamId += FSI_Kinematrix_PiProBias_md.size();
+  ExtendSystMetaData(FSImd, std::move(FSI_Kinematrix_PiProBias_md));
+
+  // If started with a sample with the hA-PiProd-bugfix,
+  // a bias variation
+  SystMetaData FSI_Kinematrix_PiProBiaswFix_md = ConfigureSetOfIndependentParameters(
+      cfg, firstParamId,
+      {kINukeKinematicsPiProBiaswFix});
+  firstParamId += FSI_Kinematrix_PiProBiaswFix_md.size();
+  ExtendSystMetaData(FSImd, std::move(FSI_Kinematrix_PiProBiaswFix_md));
 
   return FSImd;
 }

--- a/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -441,6 +441,7 @@ SystMetaData ConfigureFSIParameterHeaders(fhicl::ParameterSet const &cfg,
   SystMetaData FSI_Kinematics = ConfigureSetOfDependentParameters(
       cfg, firstParamId, tool_options, "FSI_Kinematics",
       {kINukeKinematicsTwkDial_NP_N, kINukeKinematicsTwkDial_PP_N});
+  firstParamId += FSI_Kinematics.size();
   ExtendSystMetaData(FSImd, std::move(FSI_Kinematics));
 
   // If started with a sample without the hA-PiProd-bugfix,

--- a/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -425,9 +425,9 @@ SystMetaData ConfigureFSIParameterHeaders(fhicl::ParameterSet const &cfg,
   firstParamId += FSI_N_md.size();
   ExtendSystMetaData(FSImd, std::move(FSI_N_md));
 
-  SystMetaData FSI_N_EDep_md = ConfigureSetOfDependentParameters(
-      cfg, firstParamId, tool_options, "FSI_N_EDep_VariationResponse",
-       {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,
+  SystMetaData FSI_N_EDep_md = ConfigureSetOfIndependentParameters(
+      cfg, firstParamId,
+      {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,
        kINukeTwkDial_G4LoE_N, kINukeTwkDial_INCLLoE_N,
        kINukeTwkDial_G4M1E_N, kINukeTwkDial_INCLM1E_N,
        kINukeTwkDial_G4M2E_N, kINukeTwkDial_INCLM2E_N,


### PR DESCRIPTION
Regrouping AR25 FSI dials.
- G4/INCL dials converted to independent dials
- NP/NN dials grouped "FSI_Kinematics"
- PiPro fix and bias converted to independent dials

Discussed with @gputnam in person