### PR TITLE
search the $FHICL_FILE_PATH for fhicls

### DIFF
--- a/src/nusystematics/utility/response_helper.hh
+++ b/src/nusystematics/utility/response_helper.hh
@@ -71,7 +71,9 @@ public:
     config_file = fhicl_config_filename;
 
     // TODO
-    std::unique_ptr<cet::filepath_maker> fm = std::make_unique<cet::filepath_maker>();
+    const char * fhicl_file_path = getenv("FHICL_FILE_PATH");
+    std::unique_ptr<cet::filepath_maker> fm
+        = std::make_unique<cet::filepath_lookup_nonabsolute>(fhicl_file_path ? std::string(fhicl_file_path) : "");
     fhicl::ParameterSet ps = fhicl::ParameterSet::make(config_file, *fm);
 
     LoadProvidersAndHeaders(ps.get<fhicl::ParameterSet>(

--- a/src/nusystematics/utility/response_helper.hh
+++ b/src/nusystematics/utility/response_helper.hh
@@ -71,9 +71,8 @@ public:
     config_file = fhicl_config_filename;
 
     // TODO
-    const char * fhicl_file_path = getenv("FHICL_FILE_PATH");
     std::unique_ptr<cet::filepath_maker> fm
-        = std::make_unique<cet::filepath_lookup_nonabsolute>(fhicl_file_path ? std::string(fhicl_file_path) : "");
+        = std::make_unique<cet::filepath_lookup_nonabsolute>("FHICL_FILE_PATH");
     fhicl::ParameterSet ps = fhicl::ParameterSet::make(config_file, *fm);
 
     LoadProvidersAndHeaders(ps.get<fhicl::ParameterSet>(


### PR DESCRIPTION
The default `cet::filepath_maker` type used in the current code doesn't do any fhicl file lookup.  So if your FCL isn't stored in the current directory, it won't be found, even if it's in `$FHICL_FILE_PATH`.

This PR changes it to a `cet::filepath_lookup_nonabsolute` (derived from `cet::filepath_maker`) in order to explicitly request searching the `$FHICL_FILE_PATH`.