### PR TITLE
Check GENIE versions for AR25 FSI dials

### DIFF
--- a/cmake/Templates/nusystematicsConfig.cmake.in
+++ b/cmake/Templates/nusystematicsConfig.cmake.in
@@ -15,6 +15,14 @@ if(EXISTS "${CMakeModules_CMAKE_DIR}/FindGENIE3.cmake")
 endif()
 
 find_package(GENIE3 REQUIRED)
+# Parsing GENIE version
+string(REPLACE "." ";" VERSION_LIST ${GENIE_VERSION})
+list(GET VERSION_LIST 0 MAJOR)
+list(GET VERSION_LIST 1 MINOR)
+list(GET VERSION_LIST 2 PATCH)
+math(EXPR GENIE_VERSION_CODE "${MAJOR} * 10000 + ${MINOR} * 100 + ${PATCH}")
+
+
 find_package(Eigen3 3.4.0 REQUIRED)
 
 set(nusystematics_FOUND TRUE)

--- a/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -7,7 +7,12 @@
 #include "RwCalculators/GReWeightFZone.h"
 #include "RwCalculators/GReWeightINuke.h"
 
-#if GENIE_VERSION_CODE >= 30602
+// TODO These modules are not yet merged into tagged Reweight
+// https://github.com/GENIE-MC/Reweight/pull/44
+// https://github.com/GENIE-MC/Reweight/pull/45
+// Assuming these are activated for GENIE>=3.08.00 for now (01/12/2026),
+// but need to be updated
+#if GENIE_VERSION_CODE >= 30800
 #include "RwCalculators/GReWeightINukeExtra.h"
 #include "RwCalculators/GReWeightINukeKinematics.h"
 #endif
@@ -477,7 +482,7 @@ ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
        kINukeTwkDial_FrAbs_N, kINukeTwkDial_FrPiProd_N},
       "INuke_N", []() { return new GReWeightINuke; }, UseFullHERG, param_map);
 
-#if GENIE_VERSION_CODE >= 30602
+#if GENIE_VERSION_CODE >= 30800
   AddResponseAndDependentDials(
       FSImd, "FSI_N_EDepVariationResponse",
        {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,

--- a/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -6,7 +6,12 @@
 #include "RwCalculators/GReWeightFGM.h"
 #include "RwCalculators/GReWeightFZone.h"
 #include "RwCalculators/GReWeightINuke.h"
+
+#if GENIE_VERSION_CODE >= 30602
 #include "RwCalculators/GReWeightINukeExtra.h"
+#include "RwCalculators/GReWeightINukeKinematics.h"
+#endif
+
 #include "RwCalculators/GReWeightNonResonanceBkg.h"
 #include "RwCalculators/GReWeightNuXSecCCQE.h"
 #include "RwCalculators/GReWeightNuXSecCCQEaxial.h"
@@ -19,7 +24,6 @@
 #include "RwCalculators/GReWeightNuXSecNCRES.h"
 #include "RwCalculators/GReWeightResonanceDecay.h"
 #include "RwCalculators/GReWeightDeltaradAngle.h"
-#include "RwCalculators/GReWeightINukeKinematics.h"
 
 #include <functional>
 
@@ -473,6 +477,7 @@ ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
        kINukeTwkDial_FrAbs_N, kINukeTwkDial_FrPiProd_N},
       "INuke_N", []() { return new GReWeightINuke; }, UseFullHERG, param_map);
 
+#if GENIE_VERSION_CODE >= 30602
   AddResponseAndDependentDials(
       FSImd, "FSI_N_EDepVariationResponse",
        {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,
@@ -489,6 +494,7 @@ ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
       {kINukeKinematicsTwkDial_NP_N, kINukeKinematicsTwkDial_PP_N,
        kINukeKinematicsFixPiPro, kINukeKinematicsPiProBias, kINukeKinematicsPiProBiaswFix}, 
       "FrKin", []() { return new GReWeightINukeKinematics; }, UseFullHERG, param_map);
+#endif
 
   return param_map;
 }

--- a/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -425,7 +425,7 @@ SystMetaData ConfigureFSIParameterHeaders(fhicl::ParameterSet const &cfg,
   firstParamId += FSI_N_md.size();
   ExtendSystMetaData(FSImd, std::move(FSI_N_md));
 
-#if GENIE_VERSION_CODE >= 30602
+#if GENIE_VERSION_CODE >= 30800
   SystMetaData FSI_N_EDep_md = ConfigureSetOfDependentParameters(
       cfg, firstParamId, tool_options, "FSI_N_EDep_VariationResponse",
        {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,

--- a/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -425,6 +425,7 @@ SystMetaData ConfigureFSIParameterHeaders(fhicl::ParameterSet const &cfg,
   firstParamId += FSI_N_md.size();
   ExtendSystMetaData(FSImd, std::move(FSI_N_md));
 
+#if GENIE_VERSION_CODE >= 30602
   SystMetaData FSI_N_EDep_md = ConfigureSetOfDependentParameters(
       cfg, firstParamId, tool_options, "FSI_N_EDep_VariationResponse",
        {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,
@@ -442,6 +443,7 @@ SystMetaData ConfigureFSIParameterHeaders(fhicl::ParameterSet const &cfg,
       {kINukeKinematicsTwkDial_NP_N, kINukeKinematicsTwkDial_PP_N, 
        kINukeKinematicsFixPiPro, kINukeKinematicsPiProBias, kINukeKinematicsPiProBiaswFix}); 
   ExtendSystMetaData(FSImd, std::move(FSI_Kinematics));
+#endif
 
   return FSImd;
 }


### PR DESCRIPTION
Use GENIE_VERSION for GENIE AR25 FSI dials. For now the criteria is set to >=3.08.00 as these are not yet merged:
https://github.com/GENIE-MC/Reweight/pull/44 and https://github.com/GENIE-MC/Reweight/pull/45. The purpose of having 3.08.00 (which does not exist from https://github.com/GENIE-MC/Generator is to turning them off until they became available.