### PR TITLE
Adding cmake/Modules/CheckDialValidity.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ if(NOT TARGET GENIE3::All)
   message(FATAL_ERROR "Expected find_package(GENIE3 REQUIRED) call to set up target GENIE3::All.")
 endif()
 
+include(CheckDialValidity)
+
 ###### Compiler set up
 add_library(nusystematics_dependencies INTERFACE)
 target_link_libraries(nusystematics_dependencies INTERFACE 

--- a/cmake/Modules/CheckDialValidity.cmake
+++ b/cmake/Modules/CheckDialValidity.cmake
@@ -1,0 +1,25 @@
+# Here we define various varaibles that can be used inside c++ modules
+
+# 1) GENIE version in more detail
+
+string(REPLACE "." ";" VERSION_LIST ${GENIE_VERSION})
+list(GET VERSION_LIST 0 MAJOR)
+list(GET VERSION_LIST 1 MINOR)
+list(GET VERSION_LIST 2 PATCH)
+math(EXPR GENIE_VERSION_CODE "${MAJOR} * 10000 + ${MINOR} * 100 + ${PATCH}")
+message(STATUS "GENIE_VERSION_CODE: ${GENIE_VERSION_CODE}")
+
+# AR25 FSI dials
+# TODO These modules are not yet merged into tagged Reweight
+# https://github.com/GENIE-MC/Reweight/pull/44
+# https://github.com/GENIE-MC/Reweight/pull/45
+# Assuming these are activated for GENIE>=3.08.00 for now (01/12/2026),
+# but need to be updated
+if(GENIE_VERSION_CODE GREATER_EQUAL 30800)
+  set(BUILD_AR25_FSI_DIALS 1)
+else()
+  set(BUILD_AR25_FSI_DIALS 0)
+endif()
+
+message(STATUS "BUILD_AR25_FSI_DIALS: ${BUILD_AR25_FSI_DIALS}")
+add_definitions(-DBUILD_AR25_FSI_DIALS)

--- a/cmake/Templates/nusystematicsConfig.cmake.in
+++ b/cmake/Templates/nusystematicsConfig.cmake.in
@@ -15,13 +15,6 @@ if(EXISTS "${CMakeModules_CMAKE_DIR}/FindGENIE3.cmake")
 endif()
 
 find_package(GENIE3 REQUIRED)
-# Parsing GENIE version
-string(REPLACE "." ";" VERSION_LIST ${GENIE_VERSION})
-list(GET VERSION_LIST 0 MAJOR)
-list(GET VERSION_LIST 1 MINOR)
-list(GET VERSION_LIST 2 PATCH)
-math(EXPR GENIE_VERSION_CODE "${MAJOR} * 10000 + ${MINOR} * 100 + ${PATCH}")
-
 
 find_package(Eigen3 3.4.0 REQUIRED)
 

--- a/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -12,7 +12,7 @@
 // https://github.com/GENIE-MC/Reweight/pull/45
 // Assuming these are activated for GENIE>=3.08.00 for now (01/12/2026),
 // but need to be updated
-#if GENIE_VERSION_CODE >= 30800
+#if BUILD_AR25_FSI_DIALS
 #include "RwCalculators/GReWeightINukeExtra.h"
 #include "RwCalculators/GReWeightINukeKinematics.h"
 #endif
@@ -482,7 +482,7 @@ ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
        kINukeTwkDial_FrAbs_N, kINukeTwkDial_FrPiProd_N},
       "INuke_N", []() { return new GReWeightINuke; }, UseFullHERG, param_map);
 
-#if GENIE_VERSION_CODE >= 30800
+#if BUILD_AR25_FSI_DIALS
   // Fates
   AddIndependentParameters(
       FSImd, {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,

--- a/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -425,7 +425,7 @@ SystMetaData ConfigureFSIParameterHeaders(fhicl::ParameterSet const &cfg,
   firstParamId += FSI_N_md.size();
   ExtendSystMetaData(FSImd, std::move(FSI_N_md));
 
-#if GENIE_VERSION_CODE >= 30800
+#if BUILD_AR25_FSI_DIALS
   SystMetaData FSI_N_EDep_md = ConfigureSetOfIndependentParameters(
       cfg, firstParamId,
       {kINukeTwkDial_G4_N, kINukeTwkDial_INCL_N,


### PR DESCRIPTION
Fixing previous issue where `GENIE_VERSION_CODE` is not passed to c++ modules. Now we have `cmake/Modules/CheckDialValidity.cmake`.