### PR TITLE
Add in Pion Absorption Quasi-Deuteron Reweight to Ar23+

### DIFF
--- a/fcl/Ar23+_knobs.ParamHeader.fcl
+++ b/fcl/Ar23+_knobs.ParamHeader.fcl
@@ -863,6 +863,34 @@ generated_systematic_provider_configuration: {
       }
       tool_type: "MECq0q3InterpWeighting"
    }
+   PionAbsWeighter_SBN_v3: {
+      QuasiDeuteronFraction: {
+         isSplineable: true
+         paramVariations: [
+            -3,
+            -2,
+            -1,
+            0,
+            1,
+            2,
+            3
+         ]
+         prettyName: "QuasiDeuteronFraction"
+         systParamId: 48
+      }
+      instance_name: "SBN_v3"
+      parameter_headers: [
+         "QuasiDeuteronFraction"
+      ]
+      tool_options: {
+         PionAbs_input_manifest: {
+            input_file: ""
+            inputs: []
+         }
+         verbosity_level: 5
+      }
+      tool_type: "PionAbsWeighter"
+   }
    QEInterference_SBN_v3: {
       QEIntf_dial_0: {
          isSplineable: true
@@ -1150,7 +1178,8 @@ generated_systematic_provider_configuration: {
       "ZExpPCAWeighter_MINERvA_SBN_v3",
       "MECq0q3InterpWeighting_SuSAv2ToValencia_SBN_v3",
       "MECq0q3InterpWeighting_SuSAv2ToMartini_SBN_v3",
-      "CCQEXSecCorr_SBN_v3"
+      "CCQEXSecCorr_SBN_v3",
+      "PionAbsWeighter_SBN_v3"
    ]
 }
 

--- a/fcl/Ar23+_knobs.ToolConfig.fcl
+++ b/fcl/Ar23+_knobs.ToolConfig.fcl
@@ -429,6 +429,23 @@ CCQEXSecCorr_Tool_Config: {
     fill_valid_tree: false
 }
 
+PionAbsProvider_toolconfig: {
+    tool_type: "PionAbsWeighter"
+    instance_name: "SBN_v3"
+
+    QuasiDeuteronFraction_variation_descriptor: "(-3,3,1)"
+
+    verbosity_level: 5
+
+  PionAbs_input_manifest: {
+      # Not needed, as we don't include multiplicity reweights
+      input_file: ""
+      inputs: []
+   }
+}
+
+syst_providers: [PionAbsProvider_toolconfig]
+
 
 syst_providers: [
     CCQETemplateSF_Tool_Config,
@@ -440,7 +457,8 @@ syst_providers: [
     zexpansion_weighter_MINERvA_Tool_Config,
     SuSAv2ToValencia_MECInterp_q0binned_Tool_Config,
     SuSAv2ToMartini_MECInterp_q0binned_Tool_Config,
-    CCQEXSecCorr_Tool_Config
+    CCQEXSecCorr_Tool_Config,
+    PionAbsProvider_toolconfig
 ]
 
 

--- a/src/nusystematics/systproviders/PionAbsWeighter_tool.cc
+++ b/src/nusystematics/systproviders/PionAbsWeighter_tool.cc
@@ -120,9 +120,7 @@ bool PionAbsWeighter::SetupResponseCalculator(
     for( std::vector<std::string>::iterator it_desc = descriptors.begin();
        it_desc != descriptors.end(); ++it_desc ) {
     if( !HasParam( md, *it_desc ) ) {
-      throw incorrectly_configured()
-	<< "[ERROR]: Expected to find parameter named "
-	<< std::quoted(*it_desc);
+      continue;
     }
 
     //pidx_Params[i] = GetParamIndex(md, ParamPrettyNames[i]);


### PR DESCRIPTION
Add in pionabs QD fraction to Ar23+ config. Remove check for all instances to be configured in PionAbs calculator, so we can just run the QD fraction.