### PR TITLE
don't clip weight values

### DIFF
--- a/src/nusystematics/responsecalculators/CCQETemplateReweightCalculator.hh
+++ b/src/nusystematics/responsecalculators/CCQETemplateReweightCalculator.hh
@@ -185,9 +185,6 @@ namespace nusyst {
         }
       }
 
-      // clip
-      weight = std::min(weight, 100.);
-
       return weight;
     }
 


### PR DESCRIPTION
delete the line that clipped reweight value at 100 -- in order to leave this to analyzers' decision downstream