### PR TITLE
Fix IsCorrection backward compatibility

### DIFF
--- a/src/nusystematics/app/DumpDialResponseNuSyst.cxx
+++ b/src/nusystematics/app/DumpDialResponseNuSyst.cxx
@@ -343,9 +343,9 @@ int main(int argc, char const *argv[]) {
     di.validityRange = hdr.paramValidityRange;
     di.paramVariations = hdr.paramVariations;
 
-    if (hdr.isCorrection || hdr.paramVariations.empty()) {
-      std::cout << "[INFO]: Skipping " << di.fullname
-                << " (correction or no variations)." << std::endl;
+    if (hdr.paramVariations.empty()) {
+      std::cout << "[INFO]: Skipping, " << di.fullname
+                << " has no variations." << std::endl;
       continue;
     }
 

--- a/src/nusystematics/interface/IGENIESystProvider_tool.hh
+++ b/src/nusystematics/interface/IGENIESystProvider_tool.hh
@@ -184,7 +184,7 @@ public:
       }
 
       double CVResp = hdr.isWeightSystematicVariation ? 1 : 0;
-      size_t NVars = hdr.paramVariations.size(); // note: NVars is zero for correction dial
+      size_t NVars = hdr.paramVariations.size();
 
       // If CV is different from default, find it from paramVariations and get the CV weight,
       // then divide all the weights by this CV weight.
@@ -209,7 +209,7 @@ public:
         }
         // Backward-compatibility; isCorrection header used to have empty paramVariations (here, NVars=0),
         // so manually update CVResp and responses
-        if( hdr.isCorrection ){
+        if( hdr.isCorrection && NVars==0 ){
           CVResp = pr.responses[0];
           pr.responses[0] = 1.;
         }


### PR DESCRIPTION
1. Correction dial now have size-one variation array, so should not skipped in `src/nusystematics/app/DumpDialResponseNuSyst.cxx`
2. For Backward-compatibility, `NVars==0` should be also checked.