### PR TITLE
Update GetZeroWeightResponse to properly calculate RW with RW(+1)=0

### DIFF
--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -370,14 +370,13 @@ MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
     resp.reserve(smd.size());
     for(auto const& sph : smd) {
       if (sph.isCorrection) {
-        double this_rw = 1.0 + (sph.centralParamValue) * (-1.);
-        this_rw = std::clamp(this_rw, 0., fWmax);
+        const double this_rw = std::clamp(1.0 + (sph.centralParamValue) * (-1.), 0., fWmax);
         resp.push_back({sph.systParamId, std::vector<double>{this_rw}});
       } else {
         std::vector<double> arr_rw;
+        arr_rw.reserve(sph.paramVariations.size());
         for (double d : sph.paramVariations) {
-          double this_rw = 1.0 + d * (-1.);
-          this_rw = std::clamp(this_rw, 0., fWmax);
+          const double this_rw = std::clamp(1.0 + d * (-1.), 0., fWmax);
           arr_rw.push_back(this_rw);
         }
         resp.push_back({sph.systParamId, arr_rw});

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -371,11 +371,14 @@ MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
     for(auto const& sph : smd) {
       if (sph.isCorrection) {
         double this_rw = 1.0 + (sph.centralParamValue) * (-1.);
+        this_rw = std::clamp(this_rw, 0., fWmax);
         resp.push_back({sph.systParamId, std::vector<double>{this_rw}});
       } else {
         std::vector<double> arr_rw;
         for (double d : sph.paramVariations) {
-          arr_rw.push_back(1.0 + d * (-1.));
+          double this_rw = 1.0 + d * (-1.);
+          this_rw = std::clamp(this_rw, 0., fWmax);
+          arr_rw.push_back(this_rw);
         }
         resp.push_back({sph.systParamId, arr_rw});
       }

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -363,16 +363,21 @@ MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
   ComputeQ0Q3(ev, q0, q3, Enu);
 
   // Helper lambda to create zero-weight response (suppress events)
+  // Same as setting w_eff_cv = 0 or one_sigma = -1.0
   auto GetZeroWeightResponse = [this]() {
     auto const& smd = this->GetSystMetaData();
     systtools::event_unit_response_t resp;
     resp.reserve(smd.size());
     for(auto const& sph : smd) {
-      // Create zero-weight response for this parameter
       if (sph.isCorrection) {
-        resp.push_back({sph.systParamId, std::vector<double>{0.0}});
+        double this_rw = 1.0 + (sph.centralParamValue) * (-1.);
+        resp.push_back({sph.systParamId, std::vector<double>{this_rw}});
       } else {
-        resp.push_back({sph.systParamId, std::vector<double>(sph.paramVariations.size(), 0.0)});
+        std::vector<double> arr_rw;
+        for (double d : sph.paramVariations) {
+          arr_rw.push_back(1.0 + d * (-1.));
+        }
+        resp.push_back({sph.systParamId, arr_rw});
       }
     }
     return resp;


### PR DESCRIPTION
When an event is outside the allowed phase-space of the alternative model (e.g., q3>1.2 GeV/c for SuSAv2-to-Valencia), depending on the mode, the module runs `GetZeroWeightResponse()`; it fills the reweight vector with zeros. But if a given dial (or centralValue) is not +1 sigma, this is not true. For instance, if dial=0 is given, we still want RW=1.0 not zero. This PR will properly re-calculate the RW assuming RW(+1)=0