### PR TITLE
Add flavor-specific MEC q0-q3 interpolation reweight configs

### DIFF
--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned_nue.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned_nue.ToolConfig.fcl
@@ -1,7 +1,7 @@
-SuSAv2ToMartini_MECInterp_q0binned: {
+SuSAv2ToMartini_MECInterp_q0binned_nue: {
 
   tool_type: "MECq0q3InterpWeighting"
-  instance_name: "SuSAv2ToMartini_q0binned"
+  instance_name: "SuSAv2ToMartini_q0binned_nue"
 
   # ============================================================
   # Q0-BINNED MODE: Multiple independent dials per q0 bin
@@ -32,12 +32,18 @@ SuSAv2ToMartini_MECInterp_q0binned: {
   MECResponse_input_manifest: {
 
     # ============================================================
-    # MODEL SELECTION
+    # MODEL/FLAVOR SELECTION
     # ============================================================
     Model: "martini"  # Options: "valencia" or "martini"
     
     # Base data directory
     DataBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/data"
+
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "nue"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
 
     # ============================================================
     # Q0 BINNING: Define bin edges for multiple dials
@@ -54,11 +60,12 @@ SuSAv2ToMartini_MECInterp_q0binned: {
     # ============================================================
     Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
 
-    # Full energy grid (0.4 to 2.5 GeV, 0.05 GeV step)
-    EnergyGrid : [ 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,
-                   1.0, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55,
-                   1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2.0, 2.05, 2.1, 2.15,
-                   2.2, 2.25, 2.3, 2.35, 2.4, 2.45, 2.5 ]
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20,0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
 
     # Weight limits (min, max)
     WeightLimits : [0.1, 1000.0]
@@ -71,8 +78,8 @@ SuSAv2ToMartini_MECInterp_q0binned: {
     Q3ApplyMax: 2.0
 
     # Energy window
-    EnuMin:       0.4
-    EnuMax:       2.5
+    EnuMin:       0.2
+    EnuMax:       3.0
     EnuSnapTol:   0.005
 
     HistNameNP: "h_weights_map;1"
@@ -87,4 +94,4 @@ SuSAv2ToMartini_MECInterp_q0binned: {
 
 }
 
-syst_providers : [SuSAv2ToMartini_MECInterp_q0binned]
+syst_providers : [SuSAv2ToMartini_MECInterp_q0binned_nue]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned_nuebar.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned_nuebar.ToolConfig.fcl
@@ -1,0 +1,94 @@
+SuSAv2ToMartini_MECInterp_q0binned_nuebar: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToMartini_q0binned_nuebar"
+
+  # ============================================================
+  # Q0-BINNED MODE: Multiple independent dials per q0 bin
+  # 
+  # This configuration creates 4 independent dials:
+  #   dial0: q0 [0.0, 0.2) GeV
+  #   dial1: q0 [0.2, 0.4) GeV
+  #   dial2: q0 [0.4, 0.6) GeV
+  #   dial3: q0 [0.6, 1.0) GeV
+  #
+  # EFFICIENCY: Weight templates are read ONCE and shared across
+  # all dials. Each event activates only the dial for its q0 bin.
+  # ============================================================
+
+  # Define multiple q0-binned dials (one per bin)
+  MECResponse_q0bin0_central_value: 0
+  MECResponse_q0bin0_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin1_central_value: 0
+  MECResponse_q0bin1_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin2_central_value: 0
+  MECResponse_q0bin2_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin3_central_value: 0
+  MECResponse_q0bin3_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # ============================================================
+    Model: "martini"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "nuebar"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # ============================================================
+    # Q0 BINNING: Define bin edges for multiple dials
+    # Format: [edge0, edge1, edge2, ..., edgeN]
+    # Creates N-1 bins: [edge0,edge1), [edge1,edge2), ..., [edgeN-1,edgeN]
+    # 
+    # Example: [0.0, 0.2, 0.4, 0.6, 1.0] creates 4 bins:
+    #   bin0: [0.0, 0.2)  -> dial MECResponse_q0bin0
+    #   bin1: [0.2, 0.4)  -> dial MECResponse_q0bin1
+    #   bin2: [0.4, 0.6)  -> dial MECResponse_q0bin2
+    #   bin3: [0.6, 1.0]  -> dial MECResponse_q0bin3
+    # 
+    # Events outside all bins receive weight=1.0 (no reweighting)
+    # ============================================================
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
+
+    # Full energy grid (0.30 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # Apply window for q0 and q3 (outside these ranges, weight=1.0)
+    # Martini: q0 up to 0.995 GeV, q3 up to ~2.0 GeV
+    Q0ApplyMin: 0.0
+    Q0ApplyMax: 0.995
+    Q3ApplyMin: 0.0
+    Q3ApplyMax: 2.0
+
+    # Energy window
+    EnuMin:       0.30
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    UseNearestBin: false
+    EdgeClamp: true
+    OutOfRangeWeight: 0.0
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToMartini_MECInterp_q0binned_nuebar]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned_numu.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned_numu.ToolConfig.fcl
@@ -1,0 +1,94 @@
+SuSAv2ToMartini_MECInterp_q0binned_numu: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToMartini_q0binned_numu"
+
+  # ============================================================
+  # Q0-BINNED MODE: Multiple independent dials per q0 bin
+  # 
+  # This configuration creates 4 independent dials:
+  #   dial0: q0 [0.0, 0.2) GeV
+  #   dial1: q0 [0.2, 0.4) GeV
+  #   dial2: q0 [0.4, 0.6) GeV
+  #   dial3: q0 [0.6, 1.0) GeV
+  #
+  # EFFICIENCY: Weight templates are read ONCE and shared across
+  # all dials. Each event activates only the dial for its q0 bin.
+  # ============================================================
+
+  # Define multiple q0-binned dials (one per bin)
+  MECResponse_q0bin0_central_value: 0
+  MECResponse_q0bin0_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin1_central_value: 0
+  MECResponse_q0bin1_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin2_central_value: 0
+  MECResponse_q0bin2_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin3_central_value: 0
+  MECResponse_q0bin3_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # ============================================================
+    Model: "martini"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "numu"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # ============================================================
+    # Q0 BINNING: Define bin edges for multiple dials
+    # Format: [edge0, edge1, edge2, ..., edgeN]
+    # Creates N-1 bins: [edge0,edge1), [edge1,edge2), ..., [edgeN-1,edgeN]
+    # 
+    # Example: [0.0, 0.2, 0.4, 0.6, 1.0] creates 4 bins:
+    #   bin0: [0.0, 0.2)  -> dial MECResponse_q0bin0
+    #   bin1: [0.2, 0.4)  -> dial MECResponse_q0bin1
+    #   bin2: [0.4, 0.6)  -> dial MECResponse_q0bin2
+    #   bin3: [0.6, 1.0]  -> dial MECResponse_q0bin3
+    # 
+    # Events outside all bins receive weight=1.0 (no reweighting)
+    # ============================================================
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
+
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20,0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # Apply window for q0 and q3 (outside these ranges, weight=1.0)
+    # Martini: q0 up to 0.995 GeV, q3 up to ~2.0 GeV
+    Q0ApplyMin: 0.0
+    Q0ApplyMax: 0.995
+    Q3ApplyMin: 0.0
+    Q3ApplyMax: 2.0
+
+    # Energy window
+    EnuMin:       0.2
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    UseNearestBin: false
+    EdgeClamp: true
+    OutOfRangeWeight: 0.0
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToMartini_MECInterp_q0binned_numu]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned_numubar.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_q0binned_numubar.ToolConfig.fcl
@@ -1,0 +1,94 @@
+SuSAv2ToMartini_MECInterp_q0binned_numubar: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToMartini_q0binned_numubar"
+
+  # ============================================================
+  # Q0-BINNED MODE: Multiple independent dials per q0 bin
+  # 
+  # This configuration creates 4 independent dials:
+  #   dial0: q0 [0.0, 0.2) GeV
+  #   dial1: q0 [0.2, 0.4) GeV
+  #   dial2: q0 [0.4, 0.6) GeV
+  #   dial3: q0 [0.6, 1.0) GeV
+  #
+  # EFFICIENCY: Weight templates are read ONCE and shared across
+  # all dials. Each event activates only the dial for its q0 bin.
+  # ============================================================
+
+  # Define multiple q0-binned dials (one per bin)
+  MECResponse_q0bin0_central_value: 0
+  MECResponse_q0bin0_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin1_central_value: 0
+  MECResponse_q0bin1_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin2_central_value: 0
+  MECResponse_q0bin2_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin3_central_value: 0
+  MECResponse_q0bin3_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # ============================================================
+    Model: "martini"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "numubar"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # ============================================================
+    # Q0 BINNING: Define bin edges for multiple dials
+    # Format: [edge0, edge1, edge2, ..., edgeN]
+    # Creates N-1 bins: [edge0,edge1), [edge1,edge2), ..., [edgeN-1,edgeN]
+    # 
+    # Example: [0.0, 0.2, 0.4, 0.6, 1.0] creates 4 bins:
+    #   bin0: [0.0, 0.2)  -> dial MECResponse_q0bin0
+    #   bin1: [0.2, 0.4)  -> dial MECResponse_q0bin1
+    #   bin2: [0.4, 0.6)  -> dial MECResponse_q0bin2
+    #   bin3: [0.6, 1.0]  -> dial MECResponse_q0bin3
+    # 
+    # Events outside all bins receive weight=1.0 (no reweighting)
+    # ============================================================
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
+
+    # Full energy grid (0.30 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # Apply window for q0 and q3 (outside these ranges, weight=1.0)
+    # Martini: q0 up to 0.995 GeV, q3 up to ~2.0 GeV
+    Q0ApplyMin: 0.0
+    Q0ApplyMax: 0.995
+    Q3ApplyMin: 0.0
+    Q3ApplyMax: 2.0
+
+    # Energy window
+    EnuMin:       0.30
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    UseNearestBin: false
+    EdgeClamp: true
+    OutOfRangeWeight: 0.0
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToMartini_MECInterp_q0binned_numubar]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight_nue.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight_nue.ToolConfig.fcl
@@ -1,0 +1,114 @@
+SuSAv2ToMartini_MECInterp_nue: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToMartini_nue"
+
+  # ============================================================
+  # SINGLE-DIAL MODE
+  # This configuration uses ONE dial that applies to all events.
+  # For multiple q0-binned dials, see:
+  #   SuSAv2ToMartini_MEC_q0binned_nue.ToolConfig.fcl
+  # ============================================================
+
+  # Define the systematic parameter (dial) for interpolation weighting
+  # central value 0, evaluate at -1, 0, +1 (can expand later)
+  MECResponse_central_value: 0
+  MECResponse_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # The provider generates file paths from Model, Flavor, and the map
+    # base directories below.
+    #
+    # Physics coverage:
+    #   Valencia: q0 <= 1.2 GeV, q3 <= 1.2 GeV (both limited)
+    #   Martini:  q0 <= 0.995 GeV (limited), q3 <= ~2.0 GeV (good)
+    # ============================================================
+    Model: "martini"  # Options: "valencia" or "martini"
+    
+    # Base data directory
+    DataBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/data"
+
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "nue"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20,0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # NEW: apply only in this q0 window
+    # Valencia: q0 up to 1.2 GeV
+    # Martini:  q0 up to 0.995 GeV
+    Q0ApplyMin: 0.0     # GeV
+    Q0ApplyMax: 0.995     # GeV (Valencia: 1.2, Martini: 0.995)
+
+    # NEW: apply only in this q3 window
+    # Valencia: q3 up to 1.2 GeV (limited)
+    # Martini:  q3 up to ~2.0 GeV (good coverage, use 3.0 for no limit)
+    Q3ApplyMin: 0.0     # GeV
+    Q3ApplyMax: 2.0     # GeV (Valencia: 1.2, Martini: 2.0)
+
+    # Q0 selection range (SINGLE-DIAL MODE ONLY)
+    # If both are 0, selection is disabled and reweighting applies to all q0
+    # If set, reweighting is applied ONLY in this range; outside it, weight=1
+    # Example: Q0SelectMin: 0.05, Q0SelectMax: 0.1  -> reweight only 0.05-0.1 GeV
+    # This is independent of Q0ApplyMin/Q0ApplyMax above
+    # 
+    # NOTE: For multiple q0 bins with separate dials, use Q0Bins instead.
+    #       See SuSAv2ToMartini_MEC_q0binned_nue.ToolConfig.fcl for example.
+    #       Q0SelectMin/Max is ignored when Q0Bins is set.
+    Q0SelectMin: 0.0    # GeV (0.0 = disabled)
+    Q0SelectMax: 0.0    # GeV (0.0 = disabled)
+
+    EnuMin:       0.2
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    # UseNearestBin: when true, picks the nearest histogram bin (causes
+    # step/discontinuous jumps). Prefer interpolation when possible.
+    UseNearestBin: false
+
+    # EdgeClamp: when true, clamps q0/q3 lookups to the histogram edges
+    # instead of extrapolating or using empty bins. Enabling this reduces
+    # large discontinuities and suppresses artificial peaks at the edges.
+    EdgeClamp: true
+
+    # OutOfRangeWeight: weight to return for events outside histogram bounds.
+    # Default behavior (auto-determined by Model):
+    #   - valencia: 0.0 (suppress events beyond histogram range)
+    #   - martini:  0.0 (suppress events beyond histogram range)
+    #   - custom:   1.0 (keep original prediction, backward compatible)
+    # Explicitly set to override auto-detection:
+    OutOfRangeWeight: 0.0
+
+    # IMPORTANT: OutOfRangeWeight applies to events outside HISTOGRAM bounds.
+    # For physics-based cutoffs, use Q0ApplyMax/Q3ApplyMax above:
+    #
+    # Valencia limits (both q0 and q3 limited to 1.2 GeV):
+    #   Q0ApplyMax: 1.2  ->  weight=1.0 for q0>=1.2 GeV
+    #   Q3ApplyMax: 1.2  ->  weight=1.0 for q3>=1.2 GeV
+    #
+    # Martini limits (q0 limited to 0.995 GeV, q3 good to ~2.0 GeV):
+    #   Q0ApplyMax: 0.995  ->  weight=1.0 for q0>=0.995 GeV
+    #   Q3ApplyMax: 3.0    ->  effectively no q3 limit (Martini has good coverage)
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToMartini_MECInterp_nue]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight_nuebar.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight_nuebar.ToolConfig.fcl
@@ -1,0 +1,111 @@
+SuSAv2ToMartini_MECInterp_nuebar: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToMartini_nuebar"
+
+  # ============================================================
+  # SINGLE-DIAL MODE
+  # This configuration uses ONE dial that applies to all events.
+  # For multiple q0-binned dials, see:
+  #   SuSAv2ToMartini_MEC_q0binned_nuebar.ToolConfig.fcl
+  # ============================================================
+
+  # Define the systematic parameter (dial) for interpolation weighting
+  # central value 0, evaluate at -1, 0, +1 (can expand later)
+  MECResponse_central_value: 0
+  MECResponse_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # The provider generates file paths from Model, Flavor, and the map
+    # base directories below.
+    #
+    # Physics coverage:
+    #   Valencia: q0 <= 1.2 GeV, q3 <= 1.2 GeV (both limited)
+    #   Martini:  q0 <= 0.995 GeV (limited), q3 <= ~2.0 GeV (good)
+    # ============================================================
+    Model: "martini"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "nuebar"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # Full energy grid (0.30 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # NEW: apply only in this q0 window
+    # Valencia: q0 up to 1.2 GeV
+    # Martini:  q0 up to 0.995 GeV
+    Q0ApplyMin: 0.0     # GeV
+    Q0ApplyMax: 0.995     # GeV (Valencia: 1.2, Martini: 0.995)
+
+    # NEW: apply only in this q3 window
+    # Valencia: q3 up to 1.2 GeV (limited)
+    # Martini:  q3 up to ~2.0 GeV (good coverage, use 3.0 for no limit)
+    Q3ApplyMin: 0.0     # GeV
+    Q3ApplyMax: 2.0     # GeV (Valencia: 1.2, Martini: 2.0)
+
+    # Q0 selection range (SINGLE-DIAL MODE ONLY)
+    # If both are 0, selection is disabled and reweighting applies to all q0
+    # If set, reweighting is applied ONLY in this range; outside it, weight=1
+    # Example: Q0SelectMin: 0.05, Q0SelectMax: 0.1  -> reweight only 0.05-0.1 GeV
+    # This is independent of Q0ApplyMin/Q0ApplyMax above
+    # 
+    # NOTE: For multiple q0 bins with separate dials, use Q0Bins instead.
+    #       See SuSAv2ToMartini_MEC_q0binned_nuebar.ToolConfig.fcl for example.
+    #       Q0SelectMin/Max is ignored when Q0Bins is set.
+    Q0SelectMin: 0.0    # GeV (0.0 = disabled)
+    Q0SelectMax: 0.0    # GeV (0.0 = disabled)
+
+    EnuMin:       0.30
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    # UseNearestBin: when true, picks the nearest histogram bin (causes
+    # step/discontinuous jumps). Prefer interpolation when possible.
+    UseNearestBin: false
+
+    # EdgeClamp: when true, clamps q0/q3 lookups to the histogram edges
+    # instead of extrapolating or using empty bins. Enabling this reduces
+    # large discontinuities and suppresses artificial peaks at the edges.
+    EdgeClamp: true
+
+    # OutOfRangeWeight: weight to return for events outside histogram bounds.
+    # Default behavior (auto-determined by Model):
+    #   - valencia: 0.0 (suppress events beyond histogram range)
+    #   - martini:  0.0 (suppress events beyond histogram range)
+    #   - custom:   1.0 (keep original prediction, backward compatible)
+    # Explicitly set to override auto-detection:
+    OutOfRangeWeight: 0.0
+
+    # IMPORTANT: OutOfRangeWeight applies to events outside HISTOGRAM bounds.
+    # For physics-based cutoffs, use Q0ApplyMax/Q3ApplyMax above:
+    #
+    # Valencia limits (both q0 and q3 limited to 1.2 GeV):
+    #   Q0ApplyMax: 1.2  ->  weight=1.0 for q0>=1.2 GeV
+    #   Q3ApplyMax: 1.2  ->  weight=1.0 for q3>=1.2 GeV
+    #
+    # Martini limits (q0 limited to 0.995 GeV, q3 good to ~2.0 GeV):
+    #   Q0ApplyMax: 0.995  ->  weight=1.0 for q0>=0.995 GeV
+    #   Q3ApplyMax: 3.0    ->  effectively no q3 limit (Martini has good coverage)
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToMartini_MECInterp_nuebar]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight_numu.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight_numu.ToolConfig.fcl
@@ -1,0 +1,111 @@
+SuSAv2ToMartini_MECInterp_numu: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToMartini_numu"
+
+  # ============================================================
+  # SINGLE-DIAL MODE
+  # This configuration uses ONE dial that applies to all events.
+  # For multiple q0-binned dials, see:
+  #   SuSAv2ToMartini_MEC_q0binned_numu.ToolConfig.fcl
+  # ============================================================
+
+  # Define the systematic parameter (dial) for interpolation weighting
+  # central value 0, evaluate at -1, 0, +1 (can expand later)
+  MECResponse_central_value: 0
+  MECResponse_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # The provider generates file paths from Model, Flavor, and the map
+    # base directories below.
+    #
+    # Physics coverage:
+    #   Valencia: q0 <= 1.2 GeV, q3 <= 1.2 GeV (both limited)
+    #   Martini:  q0 <= 0.995 GeV (limited), q3 <= ~2.0 GeV (good)
+    # ============================================================
+    Model: "martini"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "numu"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20,0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # NEW: apply only in this q0 window
+    # Valencia: q0 up to 1.2 GeV
+    # Martini:  q0 up to 0.995 GeV
+    Q0ApplyMin: 0.0     # GeV
+    Q0ApplyMax: 0.995     # GeV (Valencia: 1.2, Martini: 0.995)
+
+    # NEW: apply only in this q3 window
+    # Valencia: q3 up to 1.2 GeV (limited)
+    # Martini:  q3 up to ~2.0 GeV (good coverage, use 3.0 for no limit)
+    Q3ApplyMin: 0.0     # GeV
+    Q3ApplyMax: 2.0     # GeV (Valencia: 1.2, Martini: 2.0)
+
+    # Q0 selection range (SINGLE-DIAL MODE ONLY)
+    # If both are 0, selection is disabled and reweighting applies to all q0
+    # If set, reweighting is applied ONLY in this range; outside it, weight=1
+    # Example: Q0SelectMin: 0.05, Q0SelectMax: 0.1  -> reweight only 0.05-0.1 GeV
+    # This is independent of Q0ApplyMin/Q0ApplyMax above
+    # 
+    # NOTE: For multiple q0 bins with separate dials, use Q0Bins instead.
+    #       See SuSAv2ToMartini_MEC_q0binned_numu.ToolConfig.fcl for example.
+    #       Q0SelectMin/Max is ignored when Q0Bins is set.
+    Q0SelectMin: 0.0    # GeV (0.0 = disabled)
+    Q0SelectMax: 0.0    # GeV (0.0 = disabled)
+
+    EnuMin:       0.2
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    # UseNearestBin: when true, picks the nearest histogram bin (causes
+    # step/discontinuous jumps). Prefer interpolation when possible.
+    UseNearestBin: false
+
+    # EdgeClamp: when true, clamps q0/q3 lookups to the histogram edges
+    # instead of extrapolating or using empty bins. Enabling this reduces
+    # large discontinuities and suppresses artificial peaks at the edges.
+    EdgeClamp: true
+
+    # OutOfRangeWeight: weight to return for events outside histogram bounds.
+    # Default behavior (auto-determined by Model):
+    #   - valencia: 0.0 (suppress events beyond histogram range)
+    #   - martini:  0.0 (suppress events beyond histogram range)
+    #   - custom:   1.0 (keep original prediction, backward compatible)
+    # Explicitly set to override auto-detection:
+    OutOfRangeWeight: 0.0
+
+    # IMPORTANT: OutOfRangeWeight applies to events outside HISTOGRAM bounds.
+    # For physics-based cutoffs, use Q0ApplyMax/Q3ApplyMax above:
+    #
+    # Valencia limits (both q0 and q3 limited to 1.2 GeV):
+    #   Q0ApplyMax: 1.2  ->  weight=1.0 for q0>=1.2 GeV
+    #   Q3ApplyMax: 1.2  ->  weight=1.0 for q3>=1.2 GeV
+    #
+    # Martini limits (q0 limited to 0.995 GeV, q3 good to ~2.0 GeV):
+    #   Q0ApplyMax: 0.995  ->  weight=1.0 for q0>=0.995 GeV
+    #   Q3ApplyMax: 3.0    ->  effectively no q3 limit (Martini has good coverage)
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToMartini_MECInterp_numu]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight_numubar.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToMartini_MEC_reweight_numubar.ToolConfig.fcl
@@ -1,0 +1,111 @@
+SuSAv2ToMartini_MECInterp_numubar: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToMartini_numubar"
+
+  # ============================================================
+  # SINGLE-DIAL MODE
+  # This configuration uses ONE dial that applies to all events.
+  # For multiple q0-binned dials, see:
+  #   SuSAv2ToMartini_MEC_q0binned_numubar.ToolConfig.fcl
+  # ============================================================
+
+  # Define the systematic parameter (dial) for interpolation weighting
+  # central value 0, evaluate at -1, 0, +1 (can expand later)
+  MECResponse_central_value: 0
+  MECResponse_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # The provider generates file paths from Model, Flavor, and the map
+    # base directories below.
+    #
+    # Physics coverage:
+    #   Valencia: q0 <= 1.2 GeV, q3 <= 1.2 GeV (both limited)
+    #   Martini:  q0 <= 0.995 GeV (limited), q3 <= ~2.0 GeV (good)
+    # ============================================================
+    Model: "martini"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "numubar"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # Full energy grid (0.30 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # NEW: apply only in this q0 window
+    # Valencia: q0 up to 1.2 GeV
+    # Martini:  q0 up to 0.995 GeV
+    Q0ApplyMin: 0.0     # GeV
+    Q0ApplyMax: 0.995     # GeV (Valencia: 1.2, Martini: 0.995)
+
+    # NEW: apply only in this q3 window
+    # Valencia: q3 up to 1.2 GeV (limited)
+    # Martini:  q3 up to ~2.0 GeV (good coverage, use 3.0 for no limit)
+    Q3ApplyMin: 0.0     # GeV
+    Q3ApplyMax: 2.0     # GeV (Valencia: 1.2, Martini: 2.0)
+
+    # Q0 selection range (SINGLE-DIAL MODE ONLY)
+    # If both are 0, selection is disabled and reweighting applies to all q0
+    # If set, reweighting is applied ONLY in this range; outside it, weight=1
+    # Example: Q0SelectMin: 0.05, Q0SelectMax: 0.1  -> reweight only 0.05-0.1 GeV
+    # This is independent of Q0ApplyMin/Q0ApplyMax above
+    # 
+    # NOTE: For multiple q0 bins with separate dials, use Q0Bins instead.
+    #       See SuSAv2ToMartini_MEC_q0binned_numubar.ToolConfig.fcl for example.
+    #       Q0SelectMin/Max is ignored when Q0Bins is set.
+    Q0SelectMin: 0.0    # GeV (0.0 = disabled)
+    Q0SelectMax: 0.0    # GeV (0.0 = disabled)
+
+    EnuMin:       0.30
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    # UseNearestBin: when true, picks the nearest histogram bin (causes
+    # step/discontinuous jumps). Prefer interpolation when possible.
+    UseNearestBin: false
+
+    # EdgeClamp: when true, clamps q0/q3 lookups to the histogram edges
+    # instead of extrapolating or using empty bins. Enabling this reduces
+    # large discontinuities and suppresses artificial peaks at the edges.
+    EdgeClamp: true
+
+    # OutOfRangeWeight: weight to return for events outside histogram bounds.
+    # Default behavior (auto-determined by Model):
+    #   - valencia: 0.0 (suppress events beyond histogram range)
+    #   - martini:  0.0 (suppress events beyond histogram range)
+    #   - custom:   1.0 (keep original prediction, backward compatible)
+    # Explicitly set to override auto-detection:
+    OutOfRangeWeight: 0.0
+
+    # IMPORTANT: OutOfRangeWeight applies to events outside HISTOGRAM bounds.
+    # For physics-based cutoffs, use Q0ApplyMax/Q3ApplyMax above:
+    #
+    # Valencia limits (both q0 and q3 limited to 1.2 GeV):
+    #   Q0ApplyMax: 1.2  ->  weight=1.0 for q0>=1.2 GeV
+    #   Q3ApplyMax: 1.2  ->  weight=1.0 for q3>=1.2 GeV
+    #
+    # Martini limits (q0 limited to 0.995 GeV, q3 good to ~2.0 GeV):
+    #   Q0ApplyMax: 0.995  ->  weight=1.0 for q0>=0.995 GeV
+    #   Q3ApplyMax: 3.0    ->  effectively no q3 limit (Martini has good coverage)
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToMartini_MECInterp_numubar]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned_nue.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned_nue.ToolConfig.fcl
@@ -1,7 +1,7 @@
-SuSAv2ToValenica_MECInterp_q0binned: {
+SuSAv2ToValenica_MECInterp_q0binned_nue: {
 
   tool_type: "MECq0q3InterpWeighting"
-  instance_name: "SuSAv2ToValenica_q0binned"
+  instance_name: "SuSAv2ToValenica_q0binned_nue"
 
   # ============================================================
   # Q0-BINNED MODE: Multiple independent dials per q0 bin
@@ -32,12 +32,18 @@ SuSAv2ToValenica_MECInterp_q0binned: {
   MECResponse_input_manifest: {
 
     # ============================================================
-    # MODEL SELECTION
+    # MODEL/FLAVOR SELECTION
     # ============================================================
     Model: "valencia"  # Options: "valencia" or "martini"
     
     # Base data directory
     DataBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/data"
+
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "nue"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
 
     # ============================================================
     # Q0 BINNING: Define bin edges for multiple dials
@@ -54,11 +60,12 @@ SuSAv2ToValenica_MECInterp_q0binned: {
     # ============================================================
     Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
 
-    # Full energy grid (0.4 to 2.5 GeV, 0.05 GeV step)
-    EnergyGrid : [ 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,
-                   1.0, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55,
-                   1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2.0, 2.05, 2.1, 2.15,
-                   2.2, 2.25, 2.3, 2.35, 2.4, 2.45, 2.5 ]
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
 
     # Weight limits (min, max)
     WeightLimits : [0.1, 1000.0]
@@ -71,8 +78,8 @@ SuSAv2ToValenica_MECInterp_q0binned: {
     Q3ApplyMax: 1.2
 
     # Energy window
-    EnuMin:       0.4
-    EnuMax:       2.5
+    EnuMin:       0.2
+    EnuMax:       3.0
     EnuSnapTol:   0.005
 
     HistNameNP: "h_weights_map;1"
@@ -87,4 +94,4 @@ SuSAv2ToValenica_MECInterp_q0binned: {
 
 }
 
-syst_providers : [SuSAv2ToValenica_MECInterp_q0binned]
+syst_providers : [SuSAv2ToValenica_MECInterp_q0binned_nue]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned_nuebar.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned_nuebar.ToolConfig.fcl
@@ -1,0 +1,94 @@
+SuSAv2ToValenica_MECInterp_q0binned_nuebar: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToValenica_q0binned_nuebar"
+
+  # ============================================================
+  # Q0-BINNED MODE: Multiple independent dials per q0 bin
+  # 
+  # This configuration creates 4 independent dials:
+  #   dial0: q0 [0.0, 0.2) GeV
+  #   dial1: q0 [0.2, 0.4) GeV
+  #   dial2: q0 [0.4, 0.6) GeV
+  #   dial3: q0 [0.6, 1.0) GeV
+  #
+  # EFFICIENCY: Weight templates are read ONCE and shared across
+  # all dials. Each event activates only the dial for its q0 bin.
+  # ============================================================
+
+  # Define multiple q0-binned dials (one per bin)
+  MECResponse_q0bin0_central_value: 0
+  MECResponse_q0bin0_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin1_central_value: 0
+  MECResponse_q0bin1_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin2_central_value: 0
+  MECResponse_q0bin2_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin3_central_value: 0
+  MECResponse_q0bin3_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # ============================================================
+    Model: "valencia"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "nuebar"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # ============================================================
+    # Q0 BINNING: Define bin edges for multiple dials
+    # Format: [edge0, edge1, edge2, ..., edgeN]
+    # Creates N-1 bins: [edge0,edge1), [edge1,edge2), ..., [edgeN-1,edgeN]
+    # 
+    # Example: [0.0, 0.2, 0.4, 0.6, 1.0] creates 4 bins:
+    #   bin0: [0.0, 0.2)  -> dial MECResponse_q0bin0
+    #   bin1: [0.2, 0.4)  -> dial MECResponse_q0bin1
+    #   bin2: [0.4, 0.6)  -> dial MECResponse_q0bin2
+    #   bin3: [0.6, 1.0]  -> dial MECResponse_q0bin3
+    # 
+    # Events outside all bins receive weight=1.0 (no reweighting)
+    # ============================================================
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
+
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # Apply window for q0 and q3 (outside these ranges, weight=1.0)
+    # Valencia: q0 up to 1.2 GeV, q3 up to 1.2 GeV (both limited)
+    Q0ApplyMin: 0.0
+    Q0ApplyMax: 1.2
+    Q3ApplyMin: 0.0
+    Q3ApplyMax: 1.2
+
+    # Energy window
+    EnuMin:       0.2
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    UseNearestBin: false
+    EdgeClamp: true
+    OutOfRangeWeight: 0.0
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToValenica_MECInterp_q0binned_nuebar]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned_numu.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned_numu.ToolConfig.fcl
@@ -1,0 +1,94 @@
+SuSAv2ToValenica_MECInterp_q0binned_numu: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToValenica_q0binned_numu"
+
+  # ============================================================
+  # Q0-BINNED MODE: Multiple independent dials per q0 bin
+  # 
+  # This configuration creates 4 independent dials:
+  #   dial0: q0 [0.0, 0.2) GeV
+  #   dial1: q0 [0.2, 0.4) GeV
+  #   dial2: q0 [0.4, 0.6) GeV
+  #   dial3: q0 [0.6, 1.0) GeV
+  #
+  # EFFICIENCY: Weight templates are read ONCE and shared across
+  # all dials. Each event activates only the dial for its q0 bin.
+  # ============================================================
+
+  # Define multiple q0-binned dials (one per bin)
+  MECResponse_q0bin0_central_value: 0
+  MECResponse_q0bin0_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin1_central_value: 0
+  MECResponse_q0bin1_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin2_central_value: 0
+  MECResponse_q0bin2_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin3_central_value: 0
+  MECResponse_q0bin3_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # ============================================================
+    Model: "valencia"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "numu"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # ============================================================
+    # Q0 BINNING: Define bin edges for multiple dials
+    # Format: [edge0, edge1, edge2, ..., edgeN]
+    # Creates N-1 bins: [edge0,edge1), [edge1,edge2), ..., [edgeN-1,edgeN]
+    # 
+    # Example: [0.0, 0.2, 0.4, 0.6, 1.0] creates 4 bins:
+    #   bin0: [0.0, 0.2)  -> dial MECResponse_q0bin0
+    #   bin1: [0.2, 0.4)  -> dial MECResponse_q0bin1
+    #   bin2: [0.4, 0.6)  -> dial MECResponse_q0bin2
+    #   bin3: [0.6, 1.0]  -> dial MECResponse_q0bin3
+    # 
+    # Events outside all bins receive weight=1.0 (no reweighting)
+    # ============================================================
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
+
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # Apply window for q0 and q3 (outside these ranges, weight=1.0)
+    # Valencia: q0 up to 1.2 GeV, q3 up to 1.2 GeV (both limited)
+    Q0ApplyMin: 0.0
+    Q0ApplyMax: 1.2
+    Q3ApplyMin: 0.0
+    Q3ApplyMax: 1.2
+
+    # Energy window
+    EnuMin:       0.2
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    UseNearestBin: false
+    EdgeClamp: true
+    OutOfRangeWeight: 0.0
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToValenica_MECInterp_q0binned_numu]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned_numubar.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_q0binned_numubar.ToolConfig.fcl
@@ -1,0 +1,94 @@
+SuSAv2ToValenica_MECInterp_q0binned_numubar: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToValenica_q0binned_numubar"
+
+  # ============================================================
+  # Q0-BINNED MODE: Multiple independent dials per q0 bin
+  # 
+  # This configuration creates 4 independent dials:
+  #   dial0: q0 [0.0, 0.2) GeV
+  #   dial1: q0 [0.2, 0.4) GeV
+  #   dial2: q0 [0.4, 0.6) GeV
+  #   dial3: q0 [0.6, 1.0) GeV
+  #
+  # EFFICIENCY: Weight templates are read ONCE and shared across
+  # all dials. Each event activates only the dial for its q0 bin.
+  # ============================================================
+
+  # Define multiple q0-binned dials (one per bin)
+  MECResponse_q0bin0_central_value: 0
+  MECResponse_q0bin0_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin1_central_value: 0
+  MECResponse_q0bin1_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin2_central_value: 0
+  MECResponse_q0bin2_variation_descriptor: "[1]"
+  
+  MECResponse_q0bin3_central_value: 0
+  MECResponse_q0bin3_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # ============================================================
+    Model: "valencia"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "numubar"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # ============================================================
+    # Q0 BINNING: Define bin edges for multiple dials
+    # Format: [edge0, edge1, edge2, ..., edgeN]
+    # Creates N-1 bins: [edge0,edge1), [edge1,edge2), ..., [edgeN-1,edgeN]
+    # 
+    # Example: [0.0, 0.2, 0.4, 0.6, 1.0] creates 4 bins:
+    #   bin0: [0.0, 0.2)  -> dial MECResponse_q0bin0
+    #   bin1: [0.2, 0.4)  -> dial MECResponse_q0bin1
+    #   bin2: [0.4, 0.6)  -> dial MECResponse_q0bin2
+    #   bin3: [0.6, 1.0]  -> dial MECResponse_q0bin3
+    # 
+    # Events outside all bins receive weight=1.0 (no reweighting)
+    # ============================================================
+    Q0Bins: [0.0, 0.2, 0.4, 0.6, 10.0]  # GeV
+
+    # Full energy grid (0.25 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # Apply window for q0 and q3 (outside these ranges, weight=1.0)
+    # Valencia: q0 up to 1.2 GeV, q3 up to 1.2 GeV (both limited)
+    Q0ApplyMin: 0.0
+    Q0ApplyMax: 1.2
+    Q3ApplyMin: 0.0
+    Q3ApplyMax: 1.2
+
+    # Energy window
+    EnuMin:       0.25
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    UseNearestBin: false
+    EdgeClamp: true
+    OutOfRangeWeight: 0.0
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToValenica_MECInterp_q0binned_numubar]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight_nue.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight_nue.ToolConfig.fcl
@@ -1,13 +1,12 @@
-SuSAv2ToMartini_MECInterp: {
+SuSAv2ToValenica_MECInterp_nue: {
 
   tool_type: "MECq0q3InterpWeighting"
-  instance_name: "SuSAv2ToMartini"
+  instance_name: "SuSAv2ToValenica_nue"
 
   # ============================================================
   # SINGLE-DIAL MODE
   # This configuration uses ONE dial that applies to all events.
-  # For multiple q0-binned dials, see:
-  #   SuSAv2ToMartini_MEC_q0binned.ToolConfig.fcl
+  # For multiple q0-binned dials, see the q0binned example config.
   # ============================================================
 
   # Define the systematic parameter (dial) for interpolation weighting
@@ -18,24 +17,31 @@ SuSAv2ToMartini_MECInterp: {
   MECResponse_input_manifest: {
 
     # ============================================================
-    # MODEL SELECTION: Choose "valencia" or "martini"
-    # File paths are auto-generated based on Model and DataBaseDir
-    # No need to manually specify np_files/nn_files anymore!
+    # MODEL/FLAVOR SELECTION
+    # The provider generates file paths from Model, Flavor, and the map
+    # base directories below.
     #
     # Physics coverage:
     #   Valencia: q0 <= 1.2 GeV, q3 <= 1.2 GeV (both limited)
     #   Martini:  q0 <= 0.995 GeV (limited), q3 <= ~2.0 GeV (good)
     # ============================================================
-    Model: "martini"  # Options: "valencia" or "martini"
+    Model: "valencia"  # Options: "valencia" or "martini"
     
     # Base data directory
     DataBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/data"
 
-    # full energy grid (0.4 to 2.5 GeV, 0.05 GeV step)
-    EnergyGrid : [ 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,
-                   1.0, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55,
-                   1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2.0, 2.05, 2.1, 2.15,
-                   2.2, 2.25, 2.3, 2.35, 2.4, 2.45, 2.5 ]
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "nue"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
 
     # Weight limits (min, max)
     WeightLimits : [0.1, 1000.0]
@@ -44,13 +50,13 @@ SuSAv2ToMartini_MECInterp: {
     # Valencia: q0 up to 1.2 GeV
     # Martini:  q0 up to 0.995 GeV
     Q0ApplyMin: 0.0     # GeV
-    Q0ApplyMax: 0.995     # GeV (Valencia: 1.2, Martini: 0.995)
+    Q0ApplyMax: 1.2     # GeV (Valencia: 1.2, Martini: 0.995)
 
     # NEW: apply only in this q3 window
     # Valencia: q3 up to 1.2 GeV (limited)
     # Martini:  q3 up to ~2.0 GeV (good coverage, use 3.0 for no limit)
     Q3ApplyMin: 0.0     # GeV
-    Q3ApplyMax: 2.0     # GeV (Valencia: 1.2, Martini: 2.0)
+    Q3ApplyMax: 1.2     # GeV (Valencia: 1.2, Martini: 2.0)
 
     # Q0 selection range (SINGLE-DIAL MODE ONLY)
     # If both are 0, selection is disabled and reweighting applies to all q0
@@ -59,13 +65,12 @@ SuSAv2ToMartini_MECInterp: {
     # This is independent of Q0ApplyMin/Q0ApplyMax above
     # 
     # NOTE: For multiple q0 bins with separate dials, use Q0Bins instead.
-    #       See SuSAv2ToMartini_MEC_q0binned.ToolConfig.fcl for example.
     #       Q0SelectMin/Max is ignored when Q0Bins is set.
     Q0SelectMin: 0.0    # GeV (0.0 = disabled)
     Q0SelectMax: 0.0    # GeV (0.0 = disabled)
 
-    EnuMin:       0.4
-    EnuMax:       2.5
+    EnuMin:       0.2
+    EnuMax:       3.0
     EnuSnapTol:   0.005
 
     HistNameNP: "h_weights_map;1"
@@ -104,4 +109,4 @@ SuSAv2ToMartini_MECInterp: {
 
 }
 
-syst_providers : [SuSAv2ToMartini_MECInterp]
+syst_providers : [SuSAv2ToValenica_MECInterp_nue]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight_nuebar.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight_nuebar.ToolConfig.fcl
@@ -1,0 +1,109 @@
+SuSAv2ToValenica_MECInterp_nuebar: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToValenica_nuebar"
+
+  # ============================================================
+  # SINGLE-DIAL MODE
+  # This configuration uses ONE dial that applies to all events.
+  # For multiple q0-binned dials, see the q0binned example config.
+  # ============================================================
+
+  # Define the systematic parameter (dial) for interpolation weighting
+  # central value 0, evaluate at -1, 0, +1 (can expand later)
+  MECResponse_central_value: 0
+  MECResponse_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # The provider generates file paths from Model, Flavor, and the map
+    # base directories below.
+    #
+    # Physics coverage:
+    #   Valencia: q0 <= 1.2 GeV, q3 <= 1.2 GeV (both limited)
+    #   Martini:  q0 <= 0.995 GeV (limited), q3 <= ~2.0 GeV (good)
+    # ============================================================
+    Model: "valencia"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "nuebar"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # NEW: apply only in this q0 window
+    # Valencia: q0 up to 1.2 GeV
+    # Martini:  q0 up to 0.995 GeV
+    Q0ApplyMin: 0.0     # GeV
+    Q0ApplyMax: 1.2     # GeV (Valencia: 1.2, Martini: 0.995)
+
+    # NEW: apply only in this q3 window
+    # Valencia: q3 up to 1.2 GeV (limited)
+    # Martini:  q3 up to ~2.0 GeV (good coverage, use 3.0 for no limit)
+    Q3ApplyMin: 0.0     # GeV
+    Q3ApplyMax: 1.2     # GeV (Valencia: 1.2, Martini: 2.0)
+
+    # Q0 selection range (SINGLE-DIAL MODE ONLY)
+    # If both are 0, selection is disabled and reweighting applies to all q0
+    # If set, reweighting is applied ONLY in this range; outside it, weight=1
+    # Example: Q0SelectMin: 0.05, Q0SelectMax: 0.1  -> reweight only 0.05-0.1 GeV
+    # This is independent of Q0ApplyMin/Q0ApplyMax above
+    # 
+    # NOTE: For multiple q0 bins with separate dials, use Q0Bins instead.
+    #       Q0SelectMin/Max is ignored when Q0Bins is set.
+    Q0SelectMin: 0.0    # GeV (0.0 = disabled)
+    Q0SelectMax: 0.0    # GeV (0.0 = disabled)
+
+    EnuMin:       0.2
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    # UseNearestBin: when true, picks the nearest histogram bin (causes
+    # step/discontinuous jumps). Prefer interpolation when possible.
+    UseNearestBin: false
+
+    # EdgeClamp: when true, clamps q0/q3 lookups to the histogram edges
+    # instead of extrapolating or using empty bins. Enabling this reduces
+    # large discontinuities and suppresses artificial peaks at the edges.
+    EdgeClamp: true
+
+    # OutOfRangeWeight: weight to return for events outside histogram bounds.
+    # Default behavior (auto-determined by Model):
+    #   - valencia: 0.0 (suppress events beyond histogram range)
+    #   - martini:  0.0 (suppress events beyond histogram range)
+    #   - custom:   1.0 (keep original prediction, backward compatible)
+    # Explicitly set to override auto-detection:
+    OutOfRangeWeight: 0.0
+
+    # IMPORTANT: OutOfRangeWeight applies to events outside HISTOGRAM bounds.
+    # For physics-based cutoffs, use Q0ApplyMax/Q3ApplyMax above:
+    #
+    # Valencia limits (both q0 and q3 limited to 1.2 GeV):
+    #   Q0ApplyMax: 1.2  ->  weight=1.0 for q0>=1.2 GeV
+    #   Q3ApplyMax: 1.2  ->  weight=1.0 for q3>=1.2 GeV
+    #
+    # Martini limits (q0 limited to 0.995 GeV, q3 good to ~2.0 GeV):
+    #   Q0ApplyMax: 0.995  ->  weight=1.0 for q0>=0.995 GeV
+    #   Q3ApplyMax: 3.0    ->  effectively no q3 limit (Martini has good coverage)
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToValenica_MECInterp_nuebar]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight_numu.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight_numu.ToolConfig.fcl
@@ -1,7 +1,7 @@
-SuSAv2ToValenica_MECInterp: {
+SuSAv2ToValenica_MECInterp_numu: {
 
   tool_type: "MECq0q3InterpWeighting"
-  instance_name: "SuSAv2ToValenica"
+  instance_name: "SuSAv2ToValenica_numu"
 
   # ============================================================
   # SINGLE-DIAL MODE
@@ -17,9 +17,9 @@ SuSAv2ToValenica_MECInterp: {
   MECResponse_input_manifest: {
 
     # ============================================================
-    # MODEL SELECTION: Choose "valencia" or "martini"
-    # File paths are auto-generated based on Model and DataBaseDir
-    # No need to manually specify np_files/nn_files anymore!
+    # MODEL/FLAVOR SELECTION
+    # The provider generates file paths from Model, Flavor, and the map
+    # base directories below.
     #
     # Physics coverage:
     #   Valencia: q0 <= 1.2 GeV, q3 <= 1.2 GeV (both limited)
@@ -27,14 +27,18 @@ SuSAv2ToValenica_MECInterp: {
     # ============================================================
     Model: "valencia"  # Options: "valencia" or "martini"
     
-    # Base data directory
-    DataBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/data"
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "numu"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
 
-    # full energy grid (0.4 to 2.5 GeV, 0.05 GeV step)
-    EnergyGrid : [ 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,
-                   1.0, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55,
-                   1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2.0, 2.05, 2.1, 2.15,
-                   2.2, 2.25, 2.3, 2.35, 2.4, 2.45, 2.5 ]
+    # Full energy grid (0.20 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
 
     # Weight limits (min, max)
     WeightLimits : [0.1, 1000.0]
@@ -62,8 +66,8 @@ SuSAv2ToValenica_MECInterp: {
     Q0SelectMin: 0.0    # GeV (0.0 = disabled)
     Q0SelectMax: 0.0    # GeV (0.0 = disabled)
 
-    EnuMin:       0.4
-    EnuMax:       2.5
+    EnuMin:       0.2
+    EnuMax:       3.0
     EnuSnapTol:   0.005
 
     HistNameNP: "h_weights_map;1"
@@ -102,4 +106,4 @@ SuSAv2ToValenica_MECInterp: {
 
 }
 
-syst_providers : [SuSAv2ToValenica_MECInterp]
+syst_providers : [SuSAv2ToValenica_MECInterp_numu]

--- a/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight_numubar.ToolConfig.fcl
+++ b/fcl/MECq0q3InterpWeighting/SuSAv2ToValenica_MEC_reweight_numubar.ToolConfig.fcl
@@ -1,0 +1,109 @@
+SuSAv2ToValenica_MECInterp_numubar: {
+
+  tool_type: "MECq0q3InterpWeighting"
+  instance_name: "SuSAv2ToValenica_numubar"
+
+  # ============================================================
+  # SINGLE-DIAL MODE
+  # This configuration uses ONE dial that applies to all events.
+  # For multiple q0-binned dials, see the q0binned example config.
+  # ============================================================
+
+  # Define the systematic parameter (dial) for interpolation weighting
+  # central value 0, evaluate at -1, 0, +1 (can expand later)
+  MECResponse_central_value: 0
+  MECResponse_variation_descriptor: "[1]"
+
+  MECResponse_input_manifest: {
+
+    # ============================================================
+    # MODEL/FLAVOR SELECTION
+    # The provider generates file paths from Model, Flavor, and the map
+    # base directories below.
+    #
+    # Physics coverage:
+    #   Valencia: q0 <= 1.2 GeV, q3 <= 1.2 GeV (both limited)
+    #   Martini:  q0 <= 0.995 GeV (limited), q3 <= ~2.0 GeV (good)
+    # ============================================================
+    Model: "valencia"  # Options: "valencia" or "martini"
+    
+    # Flavor-selected map inputs:
+    #   Model and Flavor select <base>/<model>/<flavor>.
+    #   The provider only reads from this tree; it does not create or modify weight maps.
+    Flavor: "numubar"  # Options: "numu", "nue", "numubar", "nuebar"
+    NuisFlatWeightMapBaseDir: "/exp/icarus/app/users/hassinin/karim_nusystematics/nusystematics/weight_test_folders_all_flavors"
+
+    # Full energy grid (0.25 to 3.00 GeV, 0.05 GeV step)
+    EnergyGrid : [ 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75,
+                   0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30, 1.35,
+                   1.40, 1.45, 1.50, 1.55, 1.60, 1.65, 1.70, 1.75, 1.80, 1.85, 1.90, 1.95,
+                   2.00, 2.05, 2.10, 2.15, 2.20, 2.25, 2.30, 2.35, 2.40, 2.45, 2.50, 2.55,
+                   2.60, 2.65, 2.70, 2.75, 2.80, 2.85, 2.90, 2.95, 3.00 ]
+
+    # Weight limits (min, max)
+    WeightLimits : [0.1, 1000.0]
+
+    # NEW: apply only in this q0 window
+    # Valencia: q0 up to 1.2 GeV
+    # Martini:  q0 up to 0.995 GeV
+    Q0ApplyMin: 0.0     # GeV
+    Q0ApplyMax: 1.2     # GeV (Valencia: 1.2, Martini: 0.995)
+
+    # NEW: apply only in this q3 window
+    # Valencia: q3 up to 1.2 GeV (limited)
+    # Martini:  q3 up to ~2.0 GeV (good coverage, use 3.0 for no limit)
+    Q3ApplyMin: 0.0     # GeV
+    Q3ApplyMax: 1.2     # GeV (Valencia: 1.2, Martini: 2.0)
+
+    # Q0 selection range (SINGLE-DIAL MODE ONLY)
+    # If both are 0, selection is disabled and reweighting applies to all q0
+    # If set, reweighting is applied ONLY in this range; outside it, weight=1
+    # Example: Q0SelectMin: 0.05, Q0SelectMax: 0.1  -> reweight only 0.05-0.1 GeV
+    # This is independent of Q0ApplyMin/Q0ApplyMax above
+    # 
+    # NOTE: For multiple q0 bins with separate dials, use Q0Bins instead.
+    #       Q0SelectMin/Max is ignored when Q0Bins is set.
+    Q0SelectMin: 0.0    # GeV (0.0 = disabled)
+    Q0SelectMax: 0.0    # GeV (0.0 = disabled)
+
+    EnuMin:       0.25
+    EnuMax:       3.0
+    EnuSnapTol:   0.005
+
+    HistNameNP: "h_weights_map;1"
+    HistNameNN: "h_weights_map;1"
+    MapIsQ3xQ0: true
+
+    # UseNearestBin: when true, picks the nearest histogram bin (causes
+    # step/discontinuous jumps). Prefer interpolation when possible.
+    UseNearestBin: false
+
+    # EdgeClamp: when true, clamps q0/q3 lookups to the histogram edges
+    # instead of extrapolating or using empty bins. Enabling this reduces
+    # large discontinuities and suppresses artificial peaks at the edges.
+    EdgeClamp: true
+
+    # OutOfRangeWeight: weight to return for events outside histogram bounds.
+    # Default behavior (auto-determined by Model):
+    #   - valencia: 0.0 (suppress events beyond histogram range)
+    #   - martini:  0.0 (suppress events beyond histogram range)
+    #   - custom:   1.0 (keep original prediction, backward compatible)
+    # Explicitly set to override auto-detection:
+    OutOfRangeWeight: 0.0
+
+    # IMPORTANT: OutOfRangeWeight applies to events outside HISTOGRAM bounds.
+    # For physics-based cutoffs, use Q0ApplyMax/Q3ApplyMax above:
+    #
+    # Valencia limits (both q0 and q3 limited to 1.2 GeV):
+    #   Q0ApplyMax: 1.2  ->  weight=1.0 for q0>=1.2 GeV
+    #   Q3ApplyMax: 1.2  ->  weight=1.0 for q3>=1.2 GeV
+    #
+    # Martini limits (q0 limited to 0.995 GeV, q3 good to ~2.0 GeV):
+    #   Q0ApplyMax: 0.995  ->  weight=1.0 for q0>=0.995 GeV
+    #   Q3ApplyMax: 3.0    ->  effectively no q3 limit (Martini has good coverage)
+
+  }
+
+}
+
+syst_providers : [SuSAv2ToValenica_MECInterp_numubar]

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include <cmath>
+#include <fstream>
 #include <limits>
 
 // SystematicsTools helper
@@ -230,19 +231,21 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
   // Histogram sourcing:
   //  (A) WeightFile with conventional names: h_weights_map_{np|nn}_<E>GeV
   //  (B) Arrays np_files/nn_files with explicit histogram names: HistNameNP/HistNameNN
-  //  (C) Auto-generate file paths based on Model parameter
-  
-  // Read DataBaseDir for auto-generation (model already read earlier for outOfRangeWeight)
-  std::string dataBaseDir = manifest.get<std::string>("DataBaseDir", "");
+  //  (C) Flavor-selected external files under NuisFlatWeightMapBaseDir
+  //  (D) Legacy auto-generated file paths based on Model and DataBaseDir
+  const bool haveSingle = manifest.has_key("WeightFile");
 
+  std::string dataBaseDir =
+      manifest.get<std::string>("DataBaseDir", "");
   dataBaseDir = systtools::expand_env_vars(dataBaseDir);
 
+  const std::string nuisFlatBaseDir =
+      manifest.get<std::string>("NuisFlatWeightMapBaseDir", "");
+
   std::vector<std::string> np_files, nn_files;
-  
-  // If Model is specified, auto-generate file paths
-  if (!model.empty() && !dataBaseDir.empty()) {
-    std::string modelDir, filePrefix;
-    
+
+  auto set_legacy_model_info = [&](std::string& modelDir,
+                                   std::string& filePrefix) {
     if (model == "valencia") {
       modelDir = "ValenciaMECq0q3";
       filePrefix = "reweight_data_SuSAv2_to_valencia";
@@ -252,33 +255,125 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
     } else {
       throw std::runtime_error("Unknown Model: '" + model + "'. Expected 'valencia' or 'martini'");
     }
-    
-    std::cout << "[MECq0q3InterpWeighting] Auto-selecting model: " << model << "\n";
-    std::cout << "  Model directory: " << modelDir << "\n";
-    
-    // Generate file paths for each energy point
-    for (double E : fEgrid) {
-  std::string np_file = dataBaseDir + "/" + modelDir + "/" + 
-           filePrefix + "_np_" + Form("%0.2f", E) + "GeV.root";
-  std::string nn_file = dataBaseDir + "/" + modelDir + "/" + 
-           filePrefix + "_nn_" + Form("%0.2f", E) + "GeV.root";
-      np_files.push_back(np_file);
-      nn_files.push_back(nn_file);
-      std::cout << "  Generated np file: " << np_file << "\n";
-      std::cout << "  Generated nn file: " << nn_file << "\n";
+  };
+
+  auto external_model_tune = [&]() -> std::string {
+    if (model == "valencia")
+      return "g18_10a";
+    if (model == "martini")
+      return "g24_12a";
+    throw std::runtime_error("Unknown Model: '" + model + "'. Expected 'valencia' or 'martini'");
+  };
+
+  auto flavor_tag = [](const std::string& flavor) -> std::string {
+    if (flavor == "numu")
+      return "NUMU";
+    if (flavor == "nue")
+      return "NUE";
+    if (flavor == "numubar")
+      return "NUMUBAR";
+    if (flavor == "nuebar")
+      return "NUEBAR";
+    throw std::runtime_error("Unknown Flavor: '" + flavor + "'. Expected 'numu', 'nue', 'numubar', or 'nuebar'");
+  };
+
+  auto energy_label = [](double E) -> std::string {
+    return std::string(Form("%0.2f", E));
+  };
+
+  auto is_numu_local_energy = [](double E) -> bool {
+    constexpr double tol = 1e-6;
+    return E >= (0.40 - tol) && E <= (2.50 + tol);
+  };
+
+  auto require_existing_map = [&](const std::string& fname,
+                                  const std::string& flavor,
+                                  const std::string& topo,
+                                  double E) {
+    std::ifstream fin(fname.c_str());
+    if (!fin.good()) {
+      throw std::runtime_error("Missing MEC q0/q3 weight map for Model '" +
+                               model + "', Flavor '" + flavor +
+                               "', topology '" + topo + "', energy " +
+                               energy_label(E) + " GeV: " + fname);
     }
-  } else {
-    // Fallback to explicitly provided file lists
-    if (manifest.has_key("np_files") && manifest.has_key("nn_files")) {
+  };
+
+  if (!haveSingle) {
+    if (manifest.has_key("np_files") || manifest.has_key("nn_files")) {
+      if (!(manifest.has_key("np_files") && manifest.has_key("nn_files"))) {
+        throw std::runtime_error("Both np_files and nn_files are required when either is specified");
+      }
       np_files = manifest.get<std::vector<std::string>>("np_files");
       nn_files = manifest.get<std::vector<std::string>>("nn_files");
+    } else if (!nuisFlatBaseDir.empty()) {
+      if (model.empty()) {
+        throw std::runtime_error("NuisFlatWeightMapBaseDir requires Model to be 'valencia' or 'martini'");
+      }
+
+      const std::string flavor =
+          manifest.get<std::string>("Flavor", "numu");
+      const std::string flavorTag = flavor_tag(flavor);
+      const std::string tune = external_model_tune();
+
+      std::string legacyModelDir, legacyFilePrefix;
+      set_legacy_model_info(legacyModelDir, legacyFilePrefix);
+
+      std::cout << "[MECq0q3InterpWeighting] Auto-selecting model: " << model << "\n";
+      std::cout << "  Flavor: " << flavor << "\n";
+      std::cout << "  External weight map base: " << nuisFlatBaseDir << "\n";
+      if (flavor == "numu") {
+        std::cout << "  numu middle-grid folder: "
+                  << nuisFlatBaseDir << "/" << model << "/" << flavor << "\n";
+      }
+
+      auto external_path = [&](const std::string& topo, double E) {
+        return nuisFlatBaseDir + "/" + model + "/" + flavor +
+               "/weight_map_ar23_to_" + tune + "_" + flavorTag + "_" +
+               topo + "_" + energy_label(E) + "GeV.root";
+      };
+
+      auto numu_middle_grid_path = [&](const std::string& topo, double E) {
+        return nuisFlatBaseDir + "/" + model + "/" + flavor + "/" + legacyFilePrefix +
+               "_" + topo + "_" + energy_label(E) + "GeV.root";
+      };
+
+      for (double E : fEgrid) {
+        const bool useNumuMiddleGrid = (flavor == "numu" && is_numu_local_energy(E));
+        const std::string np_file = useNumuMiddleGrid ? numu_middle_grid_path("np", E)
+                                                      : external_path("np", E);
+        const std::string nn_file = useNumuMiddleGrid ? numu_middle_grid_path("nn", E)
+                                                      : external_path("nn", E);
+        require_existing_map(np_file, flavor, "np", E);
+        require_existing_map(nn_file, flavor, "nn", E);
+        np_files.push_back(np_file);
+        nn_files.push_back(nn_file);
+        std::cout << "  Generated np file: " << np_file << "\n";
+        std::cout << "  Generated nn file: " << nn_file << "\n";
+      }
+    } else if (!model.empty() && !dataBaseDir.empty()) {
+      std::string modelDir, filePrefix;
+      set_legacy_model_info(modelDir, filePrefix);
+
+      std::cout << "[MECq0q3InterpWeighting] Auto-selecting model: " << model << "\n";
+      std::cout << "  Model directory: " << modelDir << "\n";
+
+      for (double E : fEgrid) {
+        const std::string np_file = dataBaseDir + "/" + modelDir + "/" +
+            filePrefix + "_np_" + energy_label(E) + "GeV.root";
+        const std::string nn_file = dataBaseDir + "/" + modelDir + "/" +
+            filePrefix + "_nn_" + energy_label(E) + "GeV.root";
+        np_files.push_back(np_file);
+        nn_files.push_back(nn_file);
+        std::cout << "  Generated np file: " << np_file << "\n";
+        std::cout << "  Generated nn file: " << nn_file << "\n";
+      }
     }
   }
-  
-  const bool haveSingle = manifest.has_key("WeightFile");
+
   const bool haveArrays = !np_files.empty() && !nn_files.empty();
   if (!haveSingle && !haveArrays)
-    throw std::runtime_error("Need either WeightFile, (np_files & nn_files), or (Model & DataBaseDir)");
+    throw std::runtime_error("Need either WeightFile, (np_files & nn_files), (NuisFlatWeightMapBaseDir & Model), or (Model & DataBaseDir)");
 
   fCalcs.clear();
 
@@ -367,49 +462,16 @@ MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
   double q0 = 0.0, q3 = 0.0, Enu = 0.0;
   ComputeQ0Q3(ev, q0, q3, Enu);
 
-  // Helper lambda to create zero-weight response (suppress events)
-  // Same as setting w_eff_cv = 0 or one_sigma = -1.0
-  auto GetZeroWeightResponse = [this]() {
-    auto const& smd = this->GetSystMetaData();
-    systtools::event_unit_response_t resp;
-    resp.reserve(smd.size());
-    for(auto const& sph : smd) {
-      if (sph.isCorrection) {
-        const double this_rw = std::clamp(1.0 + (sph.centralParamValue) * (-1.), 0., fWmax);
-        resp.push_back({sph.systParamId, std::vector<double>{this_rw}});
-      } else {
-        std::vector<double> arr_rw;
-        arr_rw.reserve(sph.paramVariations.size());
-        for (double d : sph.paramVariations) {
-          const double this_rw = std::clamp(1.0 + d * (-1.), 0., fWmax);
-          arr_rw.push_back(this_rw);
-        }
-        resp.push_back({sph.systParamId, arr_rw});
-      }
-    }
-    return resp;
-  };
-
-  // Determine if Q0 selection/binning is enabled
-  // Either Q0SelectMin/Max OR Q0Bins means we want weight=1 outside apply windows
+  // Determine if Q0 selection is enabled.
   const bool q0SelectionEnabled = (fQ0SelectMax > 0.0);
-  const bool q0BinningEnabled = (!fQ0Bins.empty());
 
-  // NEW: q3/q0 apply window gate logic
-  // If Q0 selection OR Q0 binning is ENABLED: return weight=1 if outside apply windows
-  // If BOTH are DISABLED: return weight=0 if outside apply windows
+  // q3/q0 apply-window gate. Outside the apply window the dial has no effect,
+  // including in single-dial reweight mode.
   const bool outsideQ3Apply = (q3 <= fQ3ApplyMin + 1e-6 || q3 >= fQ3ApplyMax - 1e-6);
   const bool outsideQ0Apply = (q0 <= fQ0ApplyMin + 1e-6 || q0 >= fQ0ApplyMax - 1e-6);
-  
-  if (outsideQ3Apply || outsideQ0Apply) {
-    if (q0SelectionEnabled || q0BinningEnabled) {
-      // When Q0 selection or binning is enabled, return weight=1 outside apply region
-      return this->GetDefaultEventResponse();
-    } else {
-      // When both are disabled, return weight=0 outside apply region
-      return GetZeroWeightResponse();
-    }
-  }
+
+  if (outsideQ3Apply || outsideQ0Apply)
+    return this->GetDefaultEventResponse();
 
   // NEW: Q0 selection range: weight=1 if outside the selected range (if enabled)
   // This allows fine-grained control: e.g., apply reweight only in 0.05 < q0 < 0.1 GeV

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -229,11 +229,9 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
 
 
   // Histogram sourcing:
-  //  (A) WeightFile with conventional names: h_weights_map_{np|nn}_<E>GeV
-  //  (B) Arrays np_files/nn_files with explicit histogram names: HistNameNP/HistNameNN
-  //  (C) Flavor-selected external files under NuisFlatWeightMapBaseDir
-  //  (D) Legacy auto-generated file paths based on Model and DataBaseDir
-  const bool haveSingle = manifest.has_key("WeightFile");
+  //  (A) Arrays np_files/nn_files with explicit histogram names: HistNameNP/HistNameNN
+  //  (B) Flavor-selected external files under NuisFlatWeightMapBaseDir
+  //  (C) Legacy auto-generated file paths based on Model and DataBaseDir
 
   std::string dataBaseDir =
       manifest.get<std::string>("DataBaseDir", "");
@@ -299,7 +297,8 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
     }
   };
 
-  if (!haveSingle) {
+  // Populate the per-energy map file lists.
+  {
     if (manifest.has_key("np_files") || manifest.has_key("nn_files")) {
       if (!(manifest.has_key("np_files") && manifest.has_key("nn_files"))) {
         throw std::runtime_error("Both np_files and nn_files are required when either is specified");
@@ -370,44 +369,14 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
       }
     }
   }
-
   const bool haveArrays = !np_files.empty() && !nn_files.empty();
-  if (!haveSingle && !haveArrays)
-    throw std::runtime_error("Need either WeightFile, (np_files & nn_files), (NuisFlatWeightMapBaseDir & Model), or (Model & DataBaseDir)");
+  if (!haveArrays)
+    throw std::runtime_error("Need either (np_files & nn_files), (NuisFlatWeightMapBaseDir & Model), or (Model & DataBaseDir)");
 
   fCalcs.clear();
 
-  if (haveSingle) {
-    const std::string fname = manifest.get<std::string>("WeightFile");
-    TFile fin(fname.c_str(), "READ");
-    if (!fin.IsOpen())
-      throw std::runtime_error("Cannot open WeightFile: " + fname);
-
-    for (Topo topo : {Topo::np, Topo::nn}) {
-      const char* tag = (topo == Topo::np ? "np" : "nn");
-      auto& vec = fCalcs[topo];
-      vec.reserve(fEgrid.size());
-
-      for (double E : fEgrid) {
-  const std::string hname = Form("h_weights_map_%s_%0.2fGeV", tag, E);
-        TH2D* h = dynamic_cast<TH2D*>(fin.Get(hname.c_str()));
-        if (!h) throw std::runtime_error("Missing histogram '" + hname +
-                                         "' in file " + fname);
-
-        std::cout << "  Loaded " << fname << " :: " << hname
-                  << "  X:[" << h->GetXaxis()->GetXmin() << "," << h->GetXaxis()->GetXmax() << "]"
-                  << "  Y:[" << h->GetYaxis()->GetXmin() << "," << h->GetYaxis()->GetXmax() << "]\n";
-
-        auto calc = std::make_unique<MECq0q3ResponseCalc>(h, fWmin, fWmax, mapIsQ3xQ0);
-        calc->SetUseNearestBin(useNearestBin);
-        calc->SetEdgeClamp(edgeClamp);
-        calc->SetOutOfRangeWeight(outOfRangeWeight);
-        vec.emplace_back(std::move(calc));
-      }
-    }
-    fin.Close();
-  } else {
-    // arrays: explicit TH2 names are REQUIRED
+  {
+    // Per-energy map files use explicit TH2 names.
     if (np_files.size() != fEgrid.size() || nn_files.size() != fEgrid.size())
       throw std::runtime_error("np_files/nn_files sizes must match EnergyGrid size");
 

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.cc
@@ -95,6 +95,25 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
   const auto manifest =
       tool_opts.get<fhicl::ParameterSet>("MECResponse_input_manifest");
 
+  // Flavor-specific maps must only be applied to events with the matching
+  // incoming neutrino. Keep filtering disabled for legacy manifests that do
+  // not explicitly configure Flavor.
+  fExpectedProbePdg = 0;
+  if (manifest.has_key("Flavor")) {
+    const std::string flavor = manifest.get<std::string>("Flavor");
+    if (flavor == "numu")
+      fExpectedProbePdg = genie::kPdgNuMu;
+    else if (flavor == "nue")
+      fExpectedProbePdg = genie::kPdgNuE;
+    else if (flavor == "numubar")
+      fExpectedProbePdg = genie::kPdgAntiNuMu;
+    else if (flavor == "nuebar")
+      fExpectedProbePdg = genie::kPdgAntiNuE;
+    else
+      throw std::runtime_error("Unknown Flavor: '" + flavor +
+                               "'. Expected 'numu', 'nue', 'numubar', or 'nuebar'");
+  }
+
   // Energy grid (required)
   if (!manifest.has_key("EnergyGrid"))
     throw std::runtime_error("Missing EnergyGrid");
@@ -422,6 +441,12 @@ MECq0q3InterpWeighting::SetupResponseCalculator(fhicl::ParameterSet const &tool_
 systtools::event_unit_response_t
 MECq0q3InterpWeighting::GetEventResponse(genie::EventRecord const& ev)
 {
+  if (fExpectedProbePdg != 0) {
+    const auto* probe = ev.Probe();
+    if (!probe || probe->Pdg() != fExpectedProbePdg)
+      return this->GetDefaultEventResponse();
+  }
+
   // classify topology
   const Topo topo = ClassifyEvent(ev);
   if (topo == Topo::unknown)

--- a/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.hh
+++ b/src/nusystematics/systproviders/MECq0q3InterpWeighting_tool.hh
@@ -38,6 +38,10 @@ private:
 
   // ---- configuration/state ----
   std::vector<double> fEgrid; ///< GeV
+  // Signed incoming-neutrino PDG for flavor-specific maps. Zero leaves flavor
+  // filtering disabled for legacy manifests that do not provide Flavor.
+  int fExpectedProbePdg{0};
+
 
 
   


### PR DESCRIPTION
Add flavor-specific MEC q0-q3 interpolation reweight configs
Split the SuSAv2-to-Martini and SuSAv2-to-Valencia MEC ToolConfig files into explicit neutrino-flavor variants for nue, nuebar, numu, and numubar. Add both q0-binned and reweight configurations for each target model/flavor combination.

Update MECq0q3InterpWeighting to support the new configuration layout, and add utility environment-variable handling for resolving external MEC weight-map inputs.